### PR TITLE
feat: configure custom domain edgeshift.tech

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -29,6 +29,6 @@ module "pages" {
     NODE_VERSION = "20"
   }
 
-  # Phase 2: Uncomment when domain is purchased
-  # custom_domain = "edgeshift.dev"
+  # Custom domain
+  custom_domain = "edgeshift.tech"
 }


### PR DESCRIPTION
## Summary
- Enable custom domain `edgeshift.tech` in Terraform Cloudflare Pages module

## Changes
- Update `terraform/environments/prod/main.tf` to set `custom_domain = "edgeshift.tech"`

## Test plan
- [ ] Verify `terraform plan` shows expected changes
- [ ] Apply after merge to update Cloudflare Pages configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)