### PR TITLE
Revert: Typography plugin and Paragraph button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@astrojs/check": "^0.9.0",
         "@astrojs/node": "^9.5.1",
         "@playwright/test": "^1.57.0",
-        "@tailwindcss/typography": "^0.5.19",
         "dotenv": "^16.6.1",
         "tsx": "^4.21.0",
         "typescript": "^5.0.0"
@@ -2530,19 +2529,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/typography": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
-      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "6.0.10"
-      },
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
     "node_modules/@tailwindcss/vite": {
@@ -7250,20 +7236,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/prettier": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
@@ -9286,13 +9258,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@astrojs/check": "^0.9.0",
     "@astrojs/node": "^9.5.1",
     "@playwright/test": "^1.57.0",
-    "@tailwindcss/typography": "^0.5.19",
     "dotenv": "^16.6.1",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0"

--- a/src/components/admin/MenuBar.tsx
+++ b/src/components/admin/MenuBar.tsx
@@ -61,13 +61,6 @@ export function MenuBar({ editor }: MenuBarProps) {
       >
         H3
       </button>
-      <button
-        onClick={() => editor.chain().focus().setParagraph().run()}
-        className={buttonClass(editor.isActive('paragraph'))}
-        type="button"
-      >
-        P
-      </button>
       <div className="w-px h-6 bg-gray-300 mx-1" />
       <button
         onClick={() => editor.chain().focus().toggleBulletList().run()}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@plugin "@tailwindcss/typography";
 
 /* EdgeShift Design Tokens - Light Theme (Obsidian-inspired) */
 :root {


### PR DESCRIPTION
## Summary

Revert PR #28 to investigate RichTextEditor issues before redeployment.

## Reason

Need to verify visual feedback behavior and test thoroughly before production deployment.

## Changes

Reverts the following from PR #28:
- Remove `@tailwindcss/typography` plugin
- Remove `@plugin` directive from `global.css`
- Remove Paragraph button from MenuBar

## Next Steps

- [ ] Investigate root cause of visual feedback issues
- [ ] Add comprehensive E2E tests for admin UI
- [ ] Re-apply fix with proper testing