### PR TITLE
fix(dashboard): use timestamp fields for delivery stats

### DIFF
--- a/workers/newsletter/src/routes/dashboard.ts
+++ b/workers/newsletter/src/routes/dashboard.ts
@@ -117,10 +117,12 @@ export async function getDashboardStats(
   }>();
 
   // Calculate rates
-  // delivered status means "delivered" only, opened status means "opened", clicked means "clicked"
-  // For rate calculation: delivered base = delivered + opened + clicked (all successfully delivered)
-  const delivered = (deliveryStats?.delivered ?? 0) + (deliveryStats?.opened ?? 0) + (deliveryStats?.clicked ?? 0);
-  const opened = (deliveryStats?.opened ?? 0) + (deliveryStats?.clicked ?? 0);
+  // Timestamp-based counts are already cumulative:
+  // - delivered_at IS NOT NULL = all delivered (includes opened and clicked)
+  // - opened_at IS NOT NULL = all opened (includes clicked)
+  // - clicked_at IS NOT NULL = all clicked
+  const delivered = deliveryStats?.delivered ?? 0;
+  const opened = deliveryStats?.opened ?? 0;
   const clicked = deliveryStats?.clicked ?? 0;
 
   const openRate = delivered > 0 ? Math.round((opened / delivered) * 100 * 10) / 10 : 0;


### PR DESCRIPTION
## Summary

ダッシュボードの配信統計が正しく表示されない問題を修正。

**根本原因:** `delivery_logs.status` を使用していたが、ステータス遷移（sent → delivered → opened → clicked）により中間状態が失われていた。

**修正:** `tracking.ts` と同様に、タイムスタンプフィールド（`delivered_at`, `opened_at`, `clicked_at`）を使用するよう変更。

## Test plan

- [ ] ダッシュボード: クリック数/率が正しく表示される
- [ ] ダッシュボード: 開封数/率が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)