### PR TITLE
feat: Add time display to step sidebar

### DIFF
--- a/src/components/admin/SequenceStepEdit.tsx
+++ b/src/components/admin/SequenceStepEdit.tsx
@@ -272,6 +272,8 @@ export function SequenceStepEdit({ sequenceId, stepNumber }: SequenceStepEditPro
     step_number: index + 1,
     subject: step.subject,
     delay_days: step.delay_days,
+    delay_time: step.delay_time,
+    delay_minutes: step.delay_minutes,
   }));
 
   return (
@@ -285,6 +287,7 @@ export function SequenceStepEdit({ sequenceId, stepNumber }: SequenceStepEditPro
         onAddStep={handleAddStep}
         isMobileOpen={isMobileSidebarOpen}
         onMobileToggle={() => setIsMobileSidebarOpen(!isMobileSidebarOpen)}
+        defaultSendTime={sequence.default_send_time}
       />
 
       {/* Main content */}

--- a/src/components/admin/StepSidebar.tsx
+++ b/src/components/admin/StepSidebar.tsx
@@ -6,6 +6,8 @@ interface Step {
   step_number: number;
   subject: string;
   delay_days: number;
+  delay_time?: string;
+  delay_minutes?: number | null;
 }
 
 interface StepSidebarProps {
@@ -16,6 +18,7 @@ interface StepSidebarProps {
   onAddStep: () => void;
   isMobileOpen?: boolean;
   onMobileToggle?: () => void;
+  defaultSendTime?: string;
 }
 
 export function StepSidebar({
@@ -26,7 +29,25 @@ export function StepSidebar({
   onAddStep,
   isMobileOpen = false,
   onMobileToggle,
+  defaultSendTime = '10:00',
 }: StepSidebarProps) {
+  // Helper to format timing display
+  const formatTiming = (step: Step): string | null => {
+    // delay_minutes mode (immediate or +Xm)
+    if (step.delay_minutes !== null && step.delay_minutes !== undefined) {
+      if (step.delay_minutes === 0) {
+        return '即時送信';
+      }
+      return `+${step.delay_minutes}m`;
+    }
+
+    // delay_days mode
+    const time = step.delay_time || defaultSendTime;
+    if (step.delay_days === 0) {
+      return `当日 ${time}`;
+    }
+    return `+${step.delay_days}日 ${time}`;
+  };
   return (
     <>
       {/* Mobile toggle button */}
@@ -98,9 +119,9 @@ export function StepSidebar({
                     <span className={`text-xs font-medium ${isActive ? 'text-white' : 'text-[var(--color-text-muted)]'}`}>
                       ステップ {step.step_number}
                     </span>
-                    {step.delay_days > 0 && (
+                    {formatTiming(step) && (
                       <span className={`text-xs ${isActive ? 'text-white opacity-90' : 'text-[var(--color-text-muted)]'}`}>
-                        (+{step.delay_days}日)
+                        ({formatTiming(step)})
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

ステップ編集画面のサイドバーに時刻表示を追加。

## Before
```
ステップ 1
ステップ 2 (+1日)
```

## After
```
ステップ 1 (当日 09:00)
ステップ 2 (+1日 09:00)
```

## Changes

- `StepSidebar.tsx`: delay_time, delay_minutes, defaultSendTime を追加、formatTiming ヘルパー関数で表示
- `SequenceStepEdit.tsx`: sidebarSteps に時刻情報を追加

## 表示パターン
- 即時送信: `即時送信`
- 分指定: `+5m`
- 当日: `当日 09:00`
- N日後: `+1日 09:00`

🤖 Generated with [Claude Code](https://claude.com/claude-code)