### PR TITLE
fix: use correct content field in RSS feed

### DIFF
--- a/src/pages/newsletter/feed.xml.ts
+++ b/src/pages/newsletter/feed.xml.ts
@@ -11,7 +11,7 @@ interface Campaign {
   id: string;
   slug: string;
   subject: string;
-  content_html: string;
+  content: string;
   sent_at: string;
   created_at: string;
 }
@@ -83,7 +83,7 @@ export const GET: APIRoute = async ({ site, url }) => {
     const rssItems = articles
       .map((article) => {
         const itemUrl = `${site}newsletter/archive/${article.slug}`;
-        const description = extractPlainText(article.content_html);
+        const description = extractPlainText(article.content);
         const excerpt = description.length > 300
           ? description.substring(0, 300) + '...'
           : description;
@@ -95,7 +95,7 @@ export const GET: APIRoute = async ({ site, url }) => {
       <guid isPermaLink="true">${escapeXml(itemUrl)}</guid>
       <pubDate>${toRFC822(article.sent_at)}</pubDate>
       <description>${escapeXml(excerpt)}</description>
-      <content:encoded><![CDATA[${article.content_html}]]></content:encoded>
+      <content:encoded><![CDATA[${article.content}]]></content:encoded>
     </item>`;
       })
       .join('');


### PR DESCRIPTION
## Summary

RSS feedが存在しない`content_html`フィールドを参照していたバグを修正。

### Changes

- `feed.xml.ts`: `content_html` → `content` に変更（3箇所）

### Root Cause

P2修正（archive pages）の際にRSS feedの修正が漏れていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)