### PR TITLE
fix: remove query params from RSS feed API call

### DIFF
--- a/src/pages/newsletter/feed.xml.ts
+++ b/src/pages/newsletter/feed.xml.ts
@@ -59,8 +59,8 @@ function extractPlainText(html: string): string {
 
 export const GET: APIRoute = async ({ site, url }) => {
   try {
-    // Fetch latest 20 articles
-    const apiUrl = `${site}api/archive?limit=20&offset=0`;
+    // Fetch latest 20 articles (use default limit/offset to avoid query param routing issues)
+    const apiUrl = `${site}api/archive`;
     const response = await fetch(apiUrl);
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

RSSフィードのAPI呼び出しからクエリパラメータを削除。

### Root Cause

`/api/archive?limit=20&offset=0` が404を返す問題を発見。
Cloudflare Pages/Workersのルーティングがクエリストリングを正しく処理しない。

- `/api/archive` → 200 ✅
- `/api/archive?limit=20` → 404 ❌

### Fix

クエリパラメータを削除し、APIのデフォルト値（limit=20, offset=0）を使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)