### PR TITLE
fix: resolve newsletter archive E2E test issues

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,12 +7,14 @@ interface Props {
   title: string;
   description?: string;
   image?: string;
+  ogType?: 'website' | 'article';
 }
 
 const {
   title,
   description = 'EdgeShift - DXでビジネスのエッジを変化させる',
-  image = '/og-image.png'
+  image = '/og-image.png',
+  ogType = 'website'
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -34,7 +36,7 @@ const fullTitle = `${title} | EdgeShift`;
     <link rel="canonical" href={canonicalURL} />
 
     <!-- Open Graph -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />

--- a/src/pages/newsletter/archive/[slug].astro
+++ b/src/pages/newsletter/archive/[slug].astro
@@ -56,9 +56,9 @@ try {
   notFound = true;
 }
 
-// Redirect to archive if not found
+// Return 404 if article not found
 if (notFound || !article) {
-  return Astro.redirect('/newsletter/archive');
+  return new Response('Article not found', { status: 404 });
 }
 
 // Format date
@@ -82,9 +82,8 @@ const pageDescription = extractExcerpt(article.content);
 const ogImage = `${Astro.site}og-image.png`; // Default OG image
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription} image={ogImage}>
+<BaseLayout title={pageTitle} description={pageDescription} image={ogImage} ogType="article">
   <!-- Additional OG tags for article -->
-  <meta slot="head" property="og:type" content="article" />
   <meta slot="head" property="article:published_time" content={article.sent_at} />
   <meta slot="head" property="article:author" content="EdgeShift" />
 

--- a/tests/e2e/archive-production.spec.ts
+++ b/tests/e2e/archive-production.spec.ts
@@ -38,17 +38,19 @@ test.describe('Newsletter Archive - Production', () => {
 
     // Should have article content
     await expect(page.locator('article h1')).toBeVisible();
-    await expect(page.locator('article p').first()).toBeVisible();
+    // Article content is rendered in div.prose
+    await expect(page.locator('article div.prose')).toBeVisible();
 
     // Should have back link
     await expect(page.locator('a[href="/newsletter/archive"]')).toBeVisible();
   });
 
-  test('should have valid RSS feed', async ({ page }) => {
-    const response = await page.goto(`${BASE_URL}/newsletter/feed.xml`);
-    expect(response?.status()).toBe(200);
+  test('should have valid RSS feed', async ({ page, context }) => {
+    // Use context.request to fetch raw XML content (not browser-rendered HTML)
+    const response = await context.request.get(`${BASE_URL}/newsletter/feed.xml`);
+    expect(response.status()).toBe(200);
 
-    const content = await page.content();
+    const content = await response.text();
 
     // Should be valid XML
     expect(content).toContain('<?xml version="1.0" encoding="UTF-8"?>');


### PR DESCRIPTION
## Summary

Fixes 4 issues found during E2E testing of the Newsletter Archive feature.

## Changes

### Implementation Fixes

1. **404 handling for non-existent articles**
   - Before: Returned 302 redirect to `/newsletter/archive`
   - After: Returns 404 status with "Article not found" message

2. **OGP meta tags**
   - Before: Article pages had `og:type="website"`
   - After: Article pages now have `og:type="article"`
   - Added `ogType` prop to `BaseLayout.astro`

### Test Fixes

3. **RSS test methodology**
   - Before: Used `page.content()` which returns browser-rendered HTML
   - After: Uses `context.request.get()` to fetch raw XML content

4. **Article page test selector**
   - Before: Looked for `article p` element
   - After: Looks for `article div.prose` (matches actual structure)

## Test plan

- [x] `npm run check` - 0 errors
- [x] `npm run build` - success
- [ ] Run Playwright E2E tests after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)