### PR TITLE
feat: implement referral program for newsletter

### DIFF
--- a/docs/plans/2025-12-29-referral-program-design.md
+++ b/docs/plans/2025-12-29-referral-program-design.md
@@ -1,0 +1,241 @@
+# Referral Program Design
+
+**Date:** 2025-12-29
+**Status:** In Progress
+**Branch:** feature/referral-program
+
+## Overview
+
+Newsletter購読者が友人を紹介することで報酬（バッジ、特典）を得られるリファラルプログラムを実装する。
+
+## Goals
+
+1. 購読確認後に一意のリファラルコードを自動生成
+2. リファラルリンク経由での登録を追跡
+3. マイルストーン達成時に通知（3人、10人、50人紹介など）
+4. 管理者がマイルストーンと報酬を設定可能
+
+## Database Schema
+
+### 1. subscribers テーブル拡張
+
+```sql
+ALTER TABLE subscribers ADD COLUMN referral_code TEXT UNIQUE;
+ALTER TABLE subscribers ADD COLUMN referred_by TEXT REFERENCES subscribers(id);
+ALTER TABLE subscribers ADD COLUMN referral_count INTEGER DEFAULT 0;
+CREATE INDEX idx_subscribers_referral_code ON subscribers(referral_code);
+```
+
+### 2. referral_milestones テーブル（新規）
+
+```sql
+CREATE TABLE IF NOT EXISTS referral_milestones (
+  id TEXT PRIMARY KEY,
+  threshold INTEGER NOT NULL UNIQUE,  -- 達成に必要な紹介数
+  name TEXT NOT NULL,                 -- "Bronze Referrer", "Gold Advocate"など
+  description TEXT,
+  reward_type TEXT CHECK (reward_type IN ('badge', 'discount', 'content', 'custom')),
+  reward_value TEXT,                  -- バッジ名、割引コード、コンテンツURLなど
+  created_at INTEGER DEFAULT (unixepoch())
+);
+```
+
+### 3. referral_achievements テーブル（新規）
+
+```sql
+CREATE TABLE IF NOT EXISTS referral_achievements (
+  id TEXT PRIMARY KEY,
+  subscriber_id TEXT NOT NULL,
+  milestone_id TEXT NOT NULL,
+  achieved_at INTEGER NOT NULL,
+  notified_at INTEGER,
+  FOREIGN KEY (subscriber_id) REFERENCES subscribers(id) ON DELETE CASCADE,
+  FOREIGN KEY (milestone_id) REFERENCES referral_milestones(id) ON DELETE CASCADE,
+  UNIQUE(subscriber_id, milestone_id)
+);
+
+CREATE INDEX idx_achievements_subscriber ON referral_achievements(subscriber_id);
+CREATE INDEX idx_achievements_pending ON referral_achievements(notified_at);
+```
+
+## API Endpoints
+
+### Public API
+
+#### POST /api/subscribe
+拡張：`ref` パラメータを受け付ける
+
+```typescript
+interface SubscribeRequest {
+  email: string;
+  name?: string;
+  turnstileToken: string;
+  sequenceId?: string;
+  signupPageSlug?: string;
+  ref?: string;  // リファラルコード（新規）
+}
+```
+
+#### GET /api/referral/dashboard/:referralCode
+購読者用ダッシュボード情報を取得
+
+```typescript
+interface ReferralDashboardResponse {
+  referral_code: string;
+  referral_link: string;
+  referral_count: number;
+  achievements: {
+    id: string;
+    milestone_name: string;
+    threshold: number;
+    achieved_at: number;
+    reward_type: string;
+    reward_value: string;
+  }[];
+  next_milestone?: {
+    name: string;
+    threshold: number;
+    remaining: number;
+  };
+}
+```
+
+### Admin API (要認証)
+
+#### GET /api/admin/milestones
+マイルストーン一覧取得
+
+#### POST /api/admin/milestones
+マイルストーン作成
+
+```typescript
+interface CreateMilestoneRequest {
+  threshold: number;
+  name: string;
+  description?: string;
+  reward_type: 'badge' | 'discount' | 'content' | 'custom';
+  reward_value?: string;
+}
+```
+
+#### PUT /api/admin/milestones/:id
+マイルストーン更新
+
+#### DELETE /api/admin/milestones/:id
+マイルストーン削除
+
+#### GET /api/admin/referral-stats
+リファラル統計情報
+
+```typescript
+interface ReferralStatsResponse {
+  total_referrals: number;
+  active_referrers: number;  // 1人以上紹介した人
+  top_referrers: {
+    id: string;
+    email: string;
+    referral_count: number;
+  }[];
+}
+```
+
+## Implementation Phases
+
+### Phase 1: DB Schema Migration
+
+1. `schema.sql` にテーブル定義を追加
+2. ローカルD1にマイグレーション適用
+3. 本番適用はPRマージ後
+
+### Phase 2: Worker API
+
+1. `subscribe.ts` の拡張
+   - `ref` パラメータを受け取り、`referred_by` を設定
+   - 紹介者が存在する場合のみ記録
+
+2. `confirm.ts` の拡張
+   - 確認完了時に `referral_code` を生成
+   - 紹介者の `referral_count` をインクリメント
+   - マイルストーン達成をチェックし、`referral_achievements` に記録
+
+3. 新規ルート `routes/referral.ts`
+   - `/api/referral/dashboard/:referralCode` 実装
+
+4. 新規ルート `routes/milestones.ts`
+   - Admin API実装
+
+5. `scheduled.ts` の拡張
+   - 未通知の達成をチェックし、メール送信
+
+### Phase 3: Frontend
+
+1. 確認完了ページ (`/newsletter/confirmed`)
+   - リファラルリンクを表示
+   - コピーボタン
+
+2. リファラルダッシュボード (`/newsletter/referrals/:code`)
+   - 紹介数表示
+   - 達成バッジ表示
+   - 次のマイルストーンまでの進捗
+
+3. 管理画面 (`/admin/referrals/`)
+   - マイルストーン設定
+   - 統計ダッシュボード
+
+## Referral Code Generation
+
+```typescript
+function generateReferralCode(): string {
+  // 8文字の英数字（読みやすさ重視でO,0,I,1を除外）
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  let code = '';
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  for (const byte of bytes) {
+    code += chars[byte % chars.length];
+  }
+  return code;
+}
+```
+
+## Email Templates
+
+### 達成通知メール
+
+```html
+Subject: 🎉 紹介マイルストーン達成！ - EdgeShift Newsletter
+
+{name}さん、
+
+おめでとうございます！{milestone_name}を達成しました。
+{threshold}人の方があなたの紹介でニュースレターに登録されました。
+
+報酬: {reward_description}
+
+引き続き、EdgeShift Newsletterをお楽しみください。
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+- `referral.test.ts`: ダッシュボードAPI、紹介追跡
+- `milestones.test.ts`: マイルストーンCRUD
+- `confirm.test.ts`: リファラルコード生成、カウント更新
+
+### Integration Tests
+
+- 登録フロー全体（ref付き登録 → 確認 → カウント更新）
+- マイルストーン達成 → 通知フロー
+
+## Security Considerations
+
+1. リファラルコードは推測困難な8文字ランダム
+2. ダッシュボードは紹介コードで認証（メールでのみ送信）
+3. 自己紹介防止：同一IPからの登録は紹介としてカウントしない（オプション）
+
+## Migration Path
+
+1. feature/referral-program ブランチで実装
+2. PR作成・レビュー
+3. マージ後、本番D1にスキーマ適用
+4. Worker再デプロイ

--- a/src/components/admin/ReferralDashboard.tsx
+++ b/src/components/admin/ReferralDashboard.tsx
@@ -1,0 +1,417 @@
+import { useEffect, useState } from 'react';
+import {
+  getReferralStats,
+  getMilestones,
+  createMilestone,
+  updateMilestone,
+  deleteMilestone,
+  type ReferralMilestone,
+  type ReferralStatsResponse,
+  type RewardType,
+} from '../../utils/admin-api';
+
+interface MilestoneFormData {
+  threshold: number;
+  name: string;
+  description: string;
+  reward_type: RewardType;
+  reward_value: string;
+}
+
+const initialFormData: MilestoneFormData = {
+  threshold: 0,
+  name: '',
+  description: '',
+  reward_type: 'badge',
+  reward_value: '',
+};
+
+export function ReferralDashboard() {
+  const [stats, setStats] = useState<ReferralStatsResponse | null>(null);
+  const [milestones, setMilestones] = useState<ReferralMilestone[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Milestone form state
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [formData, setFormData] = useState<MilestoneFormData>(initialFormData);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  async function loadData() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [statsResult, milestonesResult] = await Promise.all([
+        getReferralStats(),
+        getMilestones(),
+      ]);
+
+      if (statsResult.success && statsResult.data) {
+        setStats(statsResult.data);
+      }
+
+      if (milestonesResult.success && milestonesResult.data) {
+        setMilestones(milestonesResult.data);
+      }
+    } catch (e) {
+      setError('Failed to load referral data');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function openCreateForm() {
+    setFormData(initialFormData);
+    setEditingId(null);
+    setFormError(null);
+    setIsFormOpen(true);
+  }
+
+  function openEditForm(milestone: ReferralMilestone) {
+    setFormData({
+      threshold: milestone.threshold,
+      name: milestone.name,
+      description: milestone.description || '',
+      reward_type: milestone.reward_type || 'badge',
+      reward_value: milestone.reward_value || '',
+    });
+    setEditingId(milestone.id);
+    setFormError(null);
+    setIsFormOpen(true);
+  }
+
+  function closeForm() {
+    setIsFormOpen(false);
+    setEditingId(null);
+    setFormData(initialFormData);
+    setFormError(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setFormError(null);
+
+    try {
+      if (editingId) {
+        const result = await updateMilestone(editingId, formData);
+        if (!result.success) {
+          setFormError(result.error || 'Failed to update milestone');
+          return;
+        }
+      } else {
+        const result = await createMilestone(formData);
+        if (!result.success) {
+          setFormError(result.error || 'Failed to create milestone');
+          return;
+        }
+      }
+
+      closeForm();
+      await loadData();
+    } catch (e) {
+      setFormError('An error occurred');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm('Are you sure you want to delete this milestone?')) {
+      return;
+    }
+
+    try {
+      const result = await deleteMilestone(id);
+      if (result.success) {
+        await loadData();
+      } else {
+        setError(result.error || 'Failed to delete milestone');
+      }
+    } catch (e) {
+      setError('An error occurred while deleting');
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-accent)]"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+          {error}
+        </div>
+      )}
+
+      {/* Stats Overview */}
+      <section>
+        <h2 className="text-xl font-semibold text-[var(--color-text)] mb-4">
+          統計概要
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] p-6">
+            <p className="text-sm text-[var(--color-text-secondary)] mb-1">総紹介数</p>
+            <p className="text-3xl font-bold text-[var(--color-accent)]">
+              {stats?.total_referrals || 0}
+            </p>
+          </div>
+          <div className="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] p-6">
+            <p className="text-sm text-[var(--color-text-secondary)] mb-1">アクティブな紹介者</p>
+            <p className="text-3xl font-bold text-[var(--color-text)]">
+              {stats?.active_referrers || 0}
+            </p>
+          </div>
+          <div className="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] p-6">
+            <p className="text-sm text-[var(--color-text-secondary)] mb-1">平均紹介数</p>
+            <p className="text-3xl font-bold text-[var(--color-text)]">
+              {stats?.active_referrers
+                ? (stats.total_referrals / stats.active_referrers).toFixed(1)
+                : 0}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Top Referrers */}
+      <section>
+        <h2 className="text-xl font-semibold text-[var(--color-text)] mb-4">
+          トップ紹介者
+        </h2>
+        <div className="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] overflow-hidden">
+          {stats?.top_referrers && stats.top_referrers.length > 0 ? (
+            <table className="w-full">
+              <thead className="bg-[var(--color-bg-secondary)]">
+                <tr>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-[var(--color-text-secondary)]">
+                    順位
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-[var(--color-text-secondary)]">
+                    メールアドレス
+                  </th>
+                  <th className="px-4 py-3 text-right text-sm font-medium text-[var(--color-text-secondary)]">
+                    紹介数
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--color-border)]">
+                {stats.top_referrers.map((referrer, index) => (
+                  <tr key={referrer.id} className="hover:bg-[var(--color-bg-secondary)]">
+                    <td className="px-4 py-3 text-sm text-[var(--color-text)]">
+                      #{index + 1}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[var(--color-text)]">
+                      {referrer.email}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[var(--color-text)] text-right">
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-accent)] text-white">
+                        {referrer.referral_count}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="p-8 text-center text-[var(--color-text-secondary)]">
+              まだ紹介者がいません
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Milestones Management */}
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-[var(--color-text)]">
+            マイルストーン設定
+          </h2>
+          <button
+            onClick={openCreateForm}
+            className="px-4 py-2 bg-[var(--color-accent)] text-white rounded hover:bg-[var(--color-accent-hover)] transition-colors"
+          >
+            + 追加
+          </button>
+        </div>
+
+        <div className="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] overflow-hidden">
+          {milestones.length > 0 ? (
+            <table className="w-full">
+              <thead className="bg-[var(--color-bg-secondary)]">
+                <tr>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-[var(--color-text-secondary)]">
+                    しきい値
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-[var(--color-text-secondary)]">
+                    名前
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-[var(--color-text-secondary)]">
+                    報酬タイプ
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-[var(--color-text-secondary)]">
+                    報酬値
+                  </th>
+                  <th className="px-4 py-3 text-right text-sm font-medium text-[var(--color-text-secondary)]">
+                    操作
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--color-border)]">
+                {milestones.map((milestone) => (
+                  <tr key={milestone.id} className="hover:bg-[var(--color-bg-secondary)]">
+                    <td className="px-4 py-3 text-sm text-[var(--color-text)]">
+                      {milestone.threshold}人
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[var(--color-text)]">
+                      {milestone.name}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[var(--color-text)]">
+                      {milestone.reward_type || '-'}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[var(--color-text)]">
+                      {milestone.reward_value || '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        onClick={() => openEditForm(milestone)}
+                        className="text-[var(--color-accent)] hover:underline text-sm mr-4"
+                      >
+                        編集
+                      </button>
+                      <button
+                        onClick={() => handleDelete(milestone.id)}
+                        className="text-red-600 hover:underline text-sm"
+                      >
+                        削除
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="p-8 text-center text-[var(--color-text-secondary)]">
+              マイルストーンが設定されていません
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Milestone Form Modal */}
+      {isFormOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] p-6 w-full max-w-md mx-4">
+            <h3 className="text-lg font-semibold text-[var(--color-text)] mb-4">
+              {editingId ? 'マイルストーンを編集' : 'マイルストーンを追加'}
+            </h3>
+
+            {formError && (
+              <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded text-sm">
+                {formError}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-[var(--color-text)] mb-1">
+                  しきい値（紹介数）
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={formData.threshold}
+                  onChange={(e) => setFormData({ ...formData, threshold: parseInt(e.target.value) || 0 })}
+                  className="w-full px-3 py-2 border border-[var(--color-border)] rounded bg-[var(--color-bg)] text-[var(--color-text)]"
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[var(--color-text)] mb-1">
+                  名前
+                </label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full px-3 py-2 border border-[var(--color-border)] rounded bg-[var(--color-bg)] text-[var(--color-text)]"
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[var(--color-text)] mb-1">
+                  説明
+                </label>
+                <input
+                  type="text"
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  className="w-full px-3 py-2 border border-[var(--color-border)] rounded bg-[var(--color-bg)] text-[var(--color-text)]"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[var(--color-text)] mb-1">
+                  報酬タイプ
+                </label>
+                <select
+                  value={formData.reward_type}
+                  onChange={(e) => setFormData({ ...formData, reward_type: e.target.value as RewardType })}
+                  className="w-full px-3 py-2 border border-[var(--color-border)] rounded bg-[var(--color-bg)] text-[var(--color-text)]"
+                >
+                  <option value="badge">バッジ</option>
+                  <option value="discount">割引</option>
+                  <option value="content">コンテンツ</option>
+                  <option value="custom">カスタム</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[var(--color-text)] mb-1">
+                  報酬値
+                </label>
+                <input
+                  type="text"
+                  value={formData.reward_value}
+                  onChange={(e) => setFormData({ ...formData, reward_value: e.target.value })}
+                  placeholder="例: bronze, silver, gold"
+                  className="w-full px-3 py-2 border border-[var(--color-border)] rounded bg-[var(--color-bg)] text-[var(--color-text)]"
+                />
+              </div>
+
+              <div className="flex justify-end gap-3 pt-4">
+                <button
+                  type="button"
+                  onClick={closeForm}
+                  className="px-4 py-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 bg-[var(--color-accent)] text-white rounded hover:bg-[var(--color-accent-hover)] transition-colors disabled:opacity-50"
+                >
+                  {submitting ? '保存中...' : '保存'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -53,6 +53,11 @@ const fullTitle = `${title} | EdgeShift Admin`;
               </a>
             </li>
             <li>
+              <a href="/admin/referrals" class="block px-4 py-2 rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text)] transition-colors">
+                リファラル
+              </a>
+            </li>
+            <li>
               <a href="/admin/analytics" class="block px-4 py-2 rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text)] transition-colors">
                 分析
               </a>

--- a/src/pages/admin/referrals/index.astro
+++ b/src/pages/admin/referrals/index.astro
@@ -1,0 +1,17 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+import { AuthProvider } from '../../../components/admin/AuthProvider';
+import { ReferralDashboard } from '../../../components/admin/ReferralDashboard';
+---
+
+<AdminLayout title="リファラル管理">
+  <AuthProvider client:load>
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-[var(--color-text)]">リファラルプログラム</h1>
+      <p class="text-[var(--color-text-secondary)] mt-1">
+        紹介プログラムの統計とマイルストーンを管理
+      </p>
+    </div>
+    <ReferralDashboard client:load />
+  </AuthProvider>
+</AdminLayout>

--- a/src/pages/newsletter/confirmed.astro
+++ b/src/pages/newsletter/confirmed.astro
@@ -5,10 +5,15 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 const url = new URL(Astro.request.url);
 const status = url.searchParams.get('status') || 'success';
 const message = url.searchParams.get('message');
+const referralCode = url.searchParams.get('ref');
 
 const isSuccess = status === 'success';
 const isInfo = status === 'info';
 const isError = status === 'error';
+
+// Build referral link if code is present
+const siteUrl = import.meta.env.SITE || 'https://edgeshift.tech';
+const referralLink = referralCode ? `${siteUrl}/newsletter?ref=${referralCode}` : null;
 ---
 
 <BaseLayout
@@ -61,6 +66,42 @@ const isError = status === 'error';
         {isError && (message || 'リンクが無効であるか、期限切れの可能性があります。')}
       </p>
 
+      <!-- Referral Section -->
+      {isSuccess && referralLink && (
+        <div class="mb-8 p-6 bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)]">
+          <h2 class="text-lg font-semibold text-[var(--color-text)] mb-3">
+            友達を紹介してリワードを獲得
+          </h2>
+          <p class="text-sm text-[var(--color-text-secondary)] mb-4">
+            下記のリンクを友達にシェアすると、紹介数に応じてバッジやリワードがもらえます！
+          </p>
+          <div class="flex items-center gap-2">
+            <input
+              type="text"
+              readonly
+              value={referralLink}
+              id="referral-link"
+              class="flex-1 px-3 py-2 text-sm bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded text-[var(--color-text)]"
+            />
+            <button
+              id="copy-btn"
+              class="px-4 py-2 bg-[var(--color-accent)] text-white text-sm rounded hover:bg-[var(--color-accent-hover)] transition-colors"
+            >
+              コピー
+            </button>
+          </div>
+          <p class="mt-3 text-xs text-[var(--color-text-muted)]">
+            あなたの紹介コード: <code class="bg-[var(--color-bg-secondary)] px-1.5 py-0.5 rounded">{referralCode}</code>
+          </p>
+          <a
+            href={`/newsletter/referrals/${referralCode}`}
+            class="inline-block mt-4 text-sm text-[var(--color-accent)] hover:underline"
+          >
+            紹介ダッシュボードを見る
+          </a>
+        </div>
+      )}
+
       <!-- Back to Home -->
       <a
         href="/"
@@ -76,4 +117,26 @@ const isError = status === 'error';
       )}
     </div>
   </section>
+
+  {referralLink && (
+    <script>
+      const copyBtn = document.getElementById('copy-btn');
+      const referralInput = document.getElementById('referral-link') as HTMLInputElement;
+
+      if (copyBtn && referralInput) {
+        copyBtn.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(referralInput.value);
+            const originalText = copyBtn.textContent;
+            copyBtn.textContent = 'コピー済み!';
+            setTimeout(() => {
+              copyBtn.textContent = originalText;
+            }, 2000);
+          } catch (err) {
+            console.error('Copy failed:', err);
+          }
+        });
+      }
+    </script>
+  )}
 </BaseLayout>

--- a/src/pages/newsletter/referrals/[code].astro
+++ b/src/pages/newsletter/referrals/[code].astro
@@ -1,0 +1,218 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+
+export const prerender = false;
+
+const { code } = Astro.params;
+const apiUrl = import.meta.env.PUBLIC_NEWSLETTER_API_URL || 'https://edgeshift.tech/api';
+
+interface Achievement {
+  id: string;
+  milestone_name: string;
+  threshold: number;
+  achieved_at: number;
+  reward_type: string | null;
+  reward_value: string | null;
+}
+
+interface NextMilestone {
+  name: string;
+  threshold: number;
+  remaining: number;
+}
+
+interface DashboardData {
+  referral_code: string;
+  referral_link: string;
+  referral_count: number;
+  achievements: Achievement[];
+  next_milestone?: NextMilestone;
+}
+
+let data: DashboardData | null = null;
+let error: string | null = null;
+
+try {
+  const response = await fetch(`${apiUrl}/referral/dashboard/${code}`);
+  const json = await response.json();
+
+  if (json.success && json.data) {
+    data = json.data;
+  } else {
+    error = json.error || 'Failed to load referral dashboard';
+  }
+} catch (e) {
+  error = 'Failed to connect to server';
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp * 1000).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function getBadgeColor(rewardValue: string | null): string {
+  switch (rewardValue) {
+    case 'bronze': return 'bg-amber-700';
+    case 'silver': return 'bg-gray-400';
+    case 'gold': return 'bg-yellow-500';
+    case 'platinum': return 'bg-purple-500';
+    default: return 'bg-[var(--color-accent)]';
+  }
+}
+---
+
+<BaseLayout
+  title="紹介ダッシュボード"
+  description="あなたの紹介実績を確認"
+>
+  <section class="py-24 px-4 bg-[var(--color-bg-secondary)]">
+    <div class="max-w-2xl mx-auto">
+      {error ? (
+        <div class="text-center">
+          <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-red-100 mb-8">
+            <svg class="w-10 h-10 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+          </div>
+          <h1 class="text-2xl font-bold text-[var(--color-text)] mb-4">エラー</h1>
+          <p class="text-[var(--color-text-secondary)] mb-8">{error}</p>
+          <a href="/" class="inline-block bg-[var(--color-accent)] text-white px-6 py-3 rounded font-medium hover:bg-[var(--color-accent-hover)] transition-colors">
+            トップページへ戻る
+          </a>
+        </div>
+      ) : data && (
+        <>
+          <h1 class="text-3xl font-bold text-[var(--color-text)] text-center mb-8">
+            紹介ダッシュボード
+          </h1>
+
+          <!-- Stats Card -->
+          <div class="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] p-6 mb-8">
+            <div class="text-center">
+              <p class="text-5xl font-bold text-[var(--color-accent)] mb-2">
+                {data.referral_count}
+              </p>
+              <p class="text-[var(--color-text-secondary)]">人を紹介しました</p>
+            </div>
+
+            {data.next_milestone && (
+              <div class="mt-6 pt-6 border-t border-[var(--color-border)]">
+                <div class="flex justify-between text-sm mb-2">
+                  <span class="text-[var(--color-text-secondary)]">
+                    次のマイルストーン: {data.next_milestone.name}
+                  </span>
+                  <span class="text-[var(--color-text)]">
+                    {data.referral_count}/{data.next_milestone.threshold}
+                  </span>
+                </div>
+                <div class="w-full bg-[var(--color-bg-secondary)] rounded-full h-2">
+                  <div
+                    class="bg-[var(--color-accent)] h-2 rounded-full transition-all"
+                    style={`width: ${Math.min((data.referral_count / data.next_milestone.threshold) * 100, 100)}%`}
+                  ></div>
+                </div>
+                <p class="text-xs text-[var(--color-text-muted)] mt-2">
+                  あと{data.next_milestone.remaining}人で達成!
+                </p>
+              </div>
+            )}
+          </div>
+
+          <!-- Referral Link -->
+          <div class="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] p-6 mb-8">
+            <h2 class="text-lg font-semibold text-[var(--color-text)] mb-4">
+              あなたの紹介リンク
+            </h2>
+            <div class="flex items-center gap-2">
+              <input
+                type="text"
+                readonly
+                value={data.referral_link}
+                id="referral-link"
+                class="flex-1 px-3 py-2 text-sm bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded text-[var(--color-text)]"
+              />
+              <button
+                id="copy-btn"
+                class="px-4 py-2 bg-[var(--color-accent)] text-white text-sm rounded hover:bg-[var(--color-accent-hover)] transition-colors"
+              >
+                コピー
+              </button>
+            </div>
+          </div>
+
+          <!-- Achievements -->
+          <div class="bg-[var(--color-bg)] rounded-lg border border-[var(--color-border)] p-6">
+            <h2 class="text-lg font-semibold text-[var(--color-text)] mb-4">
+              獲得したバッジ
+            </h2>
+
+            {data.achievements.length > 0 ? (
+              <div class="space-y-4">
+                {data.achievements.map((achievement) => (
+                  <div class="flex items-center gap-4 p-4 bg-[var(--color-bg-secondary)] rounded-lg">
+                    <div class={`w-12 h-12 rounded-full ${getBadgeColor(achievement.reward_value)} flex items-center justify-center`}>
+                      <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                      </svg>
+                    </div>
+                    <div class="flex-1">
+                      <p class="font-semibold text-[var(--color-text)]">
+                        {achievement.milestone_name}
+                      </p>
+                      <p class="text-sm text-[var(--color-text-secondary)]">
+                        {achievement.threshold}人紹介達成
+                      </p>
+                    </div>
+                    <div class="text-right">
+                      <p class="text-sm text-[var(--color-text-muted)]">
+                        {formatDate(achievement.achieved_at)}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div class="text-center py-8 text-[var(--color-text-secondary)]">
+                <p>まだバッジを獲得していません</p>
+                <p class="text-sm mt-2">友達を紹介してバッジをゲットしよう!</p>
+              </div>
+            )}
+          </div>
+
+          <!-- Back link -->
+          <div class="text-center mt-8">
+            <a
+              href="/"
+              class="text-[var(--color-accent)] hover:underline"
+            >
+              トップページへ戻る
+            </a>
+          </div>
+        </>
+      )}
+    </div>
+  </section>
+
+  <script>
+    const copyBtn = document.getElementById('copy-btn');
+    const referralInput = document.getElementById('referral-link') as HTMLInputElement;
+
+    if (copyBtn && referralInput) {
+      copyBtn.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(referralInput.value);
+          const originalText = copyBtn.textContent;
+          copyBtn.textContent = 'Copied!';
+          setTimeout(() => {
+            copyBtn.textContent = originalText;
+          }, 2000);
+        } catch (err) {
+          console.error('Copy failed:', err);
+        }
+      });
+    }
+  </script>
+</BaseLayout>

--- a/src/utils/admin-api.ts
+++ b/src/utils/admin-api.ts
@@ -398,3 +398,62 @@ export async function addSubscriberToList(subscriberId: string, listId: string) 
 export async function removeSubscriberFromList(subscriberId: string, listId: string) {
   return apiRequest(`/subscribers/${subscriberId}/lists/${listId}`, { method: 'DELETE' });
 }
+
+// Referral Program API
+export type RewardType = 'badge' | 'discount' | 'content' | 'custom';
+
+export interface ReferralMilestone {
+  id: string;
+  threshold: number;
+  name: string;
+  description: string | null;
+  reward_type: RewardType | null;
+  reward_value: string | null;
+  created_at: number;
+}
+
+export interface CreateMilestoneData {
+  threshold: number;
+  name: string;
+  description?: string;
+  reward_type?: RewardType;
+  reward_value?: string;
+}
+
+export interface UpdateMilestoneData {
+  threshold?: number;
+  name?: string;
+  description?: string;
+  reward_type?: RewardType;
+  reward_value?: string;
+}
+
+export interface ReferralStatsResponse {
+  total_referrals: number;
+  active_referrers: number;
+  top_referrers: {
+    id: string;
+    email: string;
+    referral_count: number;
+  }[];
+}
+
+export async function getMilestones() {
+  return apiRequest<ReferralMilestone[]>('/admin/milestones');
+}
+
+export async function createMilestone(data: CreateMilestoneData) {
+  return apiRequest<ReferralMilestone>('/admin/milestones', { method: 'POST', body: data });
+}
+
+export async function updateMilestone(id: string, data: UpdateMilestoneData) {
+  return apiRequest<ReferralMilestone>(`/admin/milestones/${id}`, { method: 'PUT', body: data });
+}
+
+export async function deleteMilestone(id: string) {
+  return apiRequest(`/admin/milestones/${id}`, { method: 'DELETE' });
+}
+
+export async function getReferralStats() {
+  return apiRequest<ReferralStatsResponse>('/admin/referral-stats');
+}

--- a/workers/newsletter/migrations/004_referral_program.sql
+++ b/workers/newsletter/migrations/004_referral_program.sql
@@ -1,0 +1,45 @@
+-- Migration: Referral Program
+-- Date: 2025-12-29
+-- Description: Add referral program support
+
+-- Add referral columns to subscribers table
+ALTER TABLE subscribers ADD COLUMN referral_code TEXT UNIQUE;
+ALTER TABLE subscribers ADD COLUMN referred_by TEXT REFERENCES subscribers(id);
+ALTER TABLE subscribers ADD COLUMN referral_count INTEGER DEFAULT 0;
+
+-- Create index for referral code lookup
+CREATE INDEX IF NOT EXISTS idx_subscribers_referral_code ON subscribers(referral_code);
+
+-- Create referral milestones table
+CREATE TABLE IF NOT EXISTS referral_milestones (
+  id TEXT PRIMARY KEY,
+  threshold INTEGER NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  description TEXT,
+  reward_type TEXT CHECK (reward_type IN ('badge', 'discount', 'content', 'custom')),
+  reward_value TEXT,
+  created_at INTEGER DEFAULT (unixepoch())
+);
+
+-- Create referral achievements table
+CREATE TABLE IF NOT EXISTS referral_achievements (
+  id TEXT PRIMARY KEY,
+  subscriber_id TEXT NOT NULL,
+  milestone_id TEXT NOT NULL,
+  achieved_at INTEGER NOT NULL,
+  notified_at INTEGER,
+  FOREIGN KEY (subscriber_id) REFERENCES subscribers(id) ON DELETE CASCADE,
+  FOREIGN KEY (milestone_id) REFERENCES referral_milestones(id) ON DELETE CASCADE,
+  UNIQUE(subscriber_id, milestone_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_achievements_subscriber ON referral_achievements(subscriber_id);
+CREATE INDEX IF NOT EXISTS idx_achievements_pending ON referral_achievements(notified_at);
+
+-- Insert default milestones
+INSERT OR IGNORE INTO referral_milestones (id, threshold, name, description, reward_type, reward_value)
+VALUES
+  ('milestone_bronze', 3, 'Bronze Referrer', '3人の友達を紹介', 'badge', 'bronze'),
+  ('milestone_silver', 10, 'Silver Advocate', '10人の友達を紹介', 'badge', 'silver'),
+  ('milestone_gold', 25, 'Gold Ambassador', '25人の友達を紹介', 'badge', 'gold'),
+  ('milestone_platinum', 50, 'Platinum Champion', '50人の友達を紹介', 'badge', 'platinum');

--- a/workers/newsletter/src/__tests__/referral.test.ts
+++ b/workers/newsletter/src/__tests__/referral.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getTestEnv, setupTestDb, cleanupTestDb } from './setup';
+import {
+  handleGetReferralDashboard,
+  handleGetMilestones,
+  handleCreateMilestone,
+  handleUpdateMilestone,
+  handleDeleteMilestone,
+  handleGetReferralStats,
+} from '../routes/referral';
+import { handleConfirm } from '../routes/confirm';
+import type { Subscriber, ReferralMilestone } from '../types';
+
+describe('Referral Program', () => {
+  beforeEach(async () => {
+    await setupTestDb();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDb();
+  });
+
+  describe('Milestone CRUD', () => {
+    it('should create a milestone', async () => {
+      const env = getTestEnv();
+      const request = new Request('http://localhost/api/admin/milestones', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${env.ADMIN_API_KEY}`,
+        },
+        body: JSON.stringify({
+          threshold: 5,
+          name: 'First Badge',
+          description: 'Get 5 referrals',
+          reward_type: 'badge',
+          reward_value: 'bronze',
+        }),
+      });
+
+      const response = await handleCreateMilestone(request, env);
+      const result = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(result.success).toBe(true);
+      expect(result.data.threshold).toBe(5);
+      expect(result.data.name).toBe('First Badge');
+    });
+
+    it('should reject duplicate threshold', async () => {
+      const env = getTestEnv();
+
+      // Create first milestone
+      await env.DB.prepare(
+        `INSERT INTO referral_milestones (id, threshold, name, reward_type) VALUES (?, ?, ?, ?)`
+      ).bind('m1', 5, 'First', 'badge').run();
+
+      // Try to create with same threshold
+      const request = new Request('http://localhost/api/admin/milestones', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${env.ADMIN_API_KEY}`,
+        },
+        body: JSON.stringify({
+          threshold: 5,
+          name: 'Duplicate',
+        }),
+      });
+
+      const response = await handleCreateMilestone(request, env);
+      expect(response.status).toBe(409);
+    });
+
+    it('should list all milestones', async () => {
+      const env = getTestEnv();
+
+      // Create milestones
+      await env.DB.batch([
+        env.DB.prepare(
+          `INSERT INTO referral_milestones (id, threshold, name) VALUES (?, ?, ?)`
+        ).bind('m1', 3, 'Bronze'),
+        env.DB.prepare(
+          `INSERT INTO referral_milestones (id, threshold, name) VALUES (?, ?, ?)`
+        ).bind('m2', 10, 'Silver'),
+      ]);
+
+      const request = new Request('http://localhost/api/admin/milestones', {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${env.ADMIN_API_KEY}` },
+      });
+
+      const response = await handleGetMilestones(request, env);
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(2);
+      // Should be ordered by threshold
+      expect(result.data[0].threshold).toBe(3);
+      expect(result.data[1].threshold).toBe(10);
+    });
+
+    it('should update a milestone', async () => {
+      const env = getTestEnv();
+
+      await env.DB.prepare(
+        `INSERT INTO referral_milestones (id, threshold, name) VALUES (?, ?, ?)`
+      ).bind('m1', 5, 'Original').run();
+
+      const request = new Request('http://localhost/api/admin/milestones/m1', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${env.ADMIN_API_KEY}`,
+        },
+        body: JSON.stringify({
+          name: 'Updated',
+          reward_type: 'discount',
+        }),
+      });
+
+      const response = await handleUpdateMilestone(request, env, 'm1');
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(true);
+      expect(result.data.name).toBe('Updated');
+      expect(result.data.reward_type).toBe('discount');
+    });
+
+    it('should delete a milestone', async () => {
+      const env = getTestEnv();
+
+      await env.DB.prepare(
+        `INSERT INTO referral_milestones (id, threshold, name) VALUES (?, ?, ?)`
+      ).bind('m1', 5, 'ToDelete').run();
+
+      const request = new Request('http://localhost/api/admin/milestones/m1', {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${env.ADMIN_API_KEY}` },
+      });
+
+      const response = await handleDeleteMilestone(request, env, 'm1');
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(true);
+
+      // Verify deletion
+      const check = await env.DB.prepare(
+        'SELECT * FROM referral_milestones WHERE id = ?'
+      ).bind('m1').first();
+      expect(check).toBeNull();
+    });
+  });
+
+  describe('Referral Dashboard', () => {
+    it('should return dashboard data for valid referral code', async () => {
+      const env = getTestEnv();
+
+      // Create referrer with referral code
+      await env.DB.prepare(
+        `INSERT INTO subscribers (id, email, status, referral_code, referral_count) VALUES (?, ?, ?, ?, ?)`
+      ).bind('ref1', 'referrer@test.com', 'active', 'ABCD1234', 5).run();
+
+      // Create milestone and achievement
+      await env.DB.prepare(
+        `INSERT INTO referral_milestones (id, threshold, name, reward_type, reward_value) VALUES (?, ?, ?, ?, ?)`
+      ).bind('m1', 3, 'Bronze', 'badge', 'bronze').run();
+
+      await env.DB.prepare(
+        `INSERT INTO referral_achievements (id, subscriber_id, milestone_id, achieved_at) VALUES (?, ?, ?, ?)`
+      ).bind('ach1', 'ref1', 'm1', Math.floor(Date.now() / 1000)).run();
+
+      // Create next milestone
+      await env.DB.prepare(
+        `INSERT INTO referral_milestones (id, threshold, name) VALUES (?, ?, ?)`
+      ).bind('m2', 10, 'Silver').run();
+
+      const request = new Request('http://localhost/api/referral/dashboard/ABCD1234', {
+        method: 'GET',
+      });
+
+      const response = await handleGetReferralDashboard(request, env, 'ABCD1234');
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(true);
+      expect(result.data.referral_code).toBe('ABCD1234');
+      expect(result.data.referral_count).toBe(5);
+      expect(result.data.achievements).toHaveLength(1);
+      expect(result.data.achievements[0].milestone_name).toBe('Bronze');
+      expect(result.data.next_milestone).toBeDefined();
+      expect(result.data.next_milestone.name).toBe('Silver');
+      expect(result.data.next_milestone.remaining).toBe(5);
+    });
+
+    it('should return 404 for invalid referral code', async () => {
+      const env = getTestEnv();
+
+      const request = new Request('http://localhost/api/referral/dashboard/INVALID', {
+        method: 'GET',
+      });
+
+      const response = await handleGetReferralDashboard(request, env, 'INVALID');
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('Referral Stats', () => {
+    it('should return referral statistics', async () => {
+      const env = getTestEnv();
+
+      // Create subscribers with referral counts
+      await env.DB.batch([
+        env.DB.prepare(
+          `INSERT INTO subscribers (id, email, status, referral_code, referral_count) VALUES (?, ?, ?, ?, ?)`
+        ).bind('s1', 'ref1@test.com', 'active', 'CODE1', 10),
+        env.DB.prepare(
+          `INSERT INTO subscribers (id, email, status, referral_code, referral_count) VALUES (?, ?, ?, ?, ?)`
+        ).bind('s2', 'ref2@test.com', 'active', 'CODE2', 5),
+        env.DB.prepare(
+          `INSERT INTO subscribers (id, email, status, referral_code, referral_count) VALUES (?, ?, ?, ?, ?)`
+        ).bind('s3', 'norefs@test.com', 'active', 'CODE3', 0),
+      ]);
+
+      const request = new Request('http://localhost/api/admin/referral-stats', {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${env.ADMIN_API_KEY}` },
+      });
+
+      const response = await handleGetReferralStats(request, env);
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(true);
+      expect(result.data.total_referrals).toBe(15);
+      expect(result.data.active_referrers).toBe(2);
+      expect(result.data.top_referrers).toHaveLength(2);
+      expect(result.data.top_referrers[0].email).toBe('ref1@test.com');
+    });
+  });
+
+  describe('Confirm with Referral', () => {
+    it('should generate referral code on confirmation', async () => {
+      const env = getTestEnv();
+
+      // Create pending subscriber
+      const confirmToken = 'test-confirm-token';
+      await env.DB.prepare(
+        `INSERT INTO subscribers (id, email, status, confirm_token) VALUES (?, ?, ?, ?)`
+      ).bind('sub1', 'new@test.com', 'pending', confirmToken).run();
+
+      const request = new Request(`http://localhost/api/newsletter/confirm/${confirmToken}`, {
+        method: 'GET',
+      });
+
+      const response = await handleConfirm(request, env, confirmToken);
+
+      // Should redirect
+      expect(response.status).toBe(302);
+      const location = response.headers.get('location');
+      expect(location).toContain('/newsletter/confirmed');
+      expect(location).toContain('ref=');
+
+      // Verify subscriber was updated
+      const subscriber = await env.DB.prepare(
+        'SELECT * FROM subscribers WHERE id = ?'
+      ).bind('sub1').first<Subscriber>();
+
+      expect(subscriber?.status).toBe('active');
+      expect(subscriber?.referral_code).toBeDefined();
+      expect(subscriber?.referral_code?.length).toBe(8);
+    });
+
+    it('should increment referrer count on confirmation', async () => {
+      const env = getTestEnv();
+
+      // Create referrer
+      await env.DB.prepare(
+        `INSERT INTO subscribers (id, email, status, referral_code, referral_count) VALUES (?, ?, ?, ?, ?)`
+      ).bind('referrer', 'referrer@test.com', 'active', 'REFCODE1', 2).run();
+
+      // Create pending subscriber with referred_by
+      const confirmToken = 'test-confirm-token';
+      await env.DB.prepare(
+        `INSERT INTO subscribers (id, email, status, confirm_token, referred_by) VALUES (?, ?, ?, ?, ?)`
+      ).bind('sub1', 'new@test.com', 'pending', confirmToken, 'referrer').run();
+
+      // Create milestone for testing achievement
+      await env.DB.prepare(
+        `INSERT INTO referral_milestones (id, threshold, name) VALUES (?, ?, ?)`
+      ).bind('m1', 3, 'Bronze').run();
+
+      const request = new Request(`http://localhost/api/newsletter/confirm/${confirmToken}`, {
+        method: 'GET',
+      });
+
+      await handleConfirm(request, env, confirmToken);
+
+      // Verify referrer's count was incremented
+      const referrer = await env.DB.prepare(
+        'SELECT referral_count FROM subscribers WHERE id = ?'
+      ).bind('referrer').first<{ referral_count: number }>();
+
+      expect(referrer?.referral_count).toBe(3);
+
+      // Verify achievement was created
+      const achievement = await env.DB.prepare(
+        'SELECT * FROM referral_achievements WHERE subscriber_id = ? AND milestone_id = ?'
+      ).bind('referrer', 'm1').first();
+
+      expect(achievement).toBeDefined();
+    });
+  });
+});

--- a/workers/newsletter/src/index.ts
+++ b/workers/newsletter/src/index.ts
@@ -54,6 +54,14 @@ import {
   handleRemoveSubscriberFromList,
 } from './routes/contact-lists';
 import { getArchiveList, getArchiveArticle } from './routes/archive';
+import {
+  handleGetReferralDashboard,
+  handleGetMilestones,
+  handleCreateMilestone,
+  handleUpdateMilestone,
+  handleDeleteMilestone,
+  handleGetReferralStats,
+} from './routes/referral';
 import { isAuthorized } from './lib/auth';
 
 export default {
@@ -234,6 +242,60 @@ export default {
       } else if (path.match(/^\/api\/signup-pages\/[^\/]+$/) && request.method === 'DELETE') {
         const id = path.replace('/api/signup-pages/', '');
         response = await handleDeleteSignupPage(request, env, id);
+      }
+      // Referral routes (public)
+      else if (path.match(/^\/api\/referral\/dashboard\/[^\/]+$/) && request.method === 'GET') {
+        const code = path.replace('/api/referral/dashboard/', '');
+        response = await handleGetReferralDashboard(request, env, code);
+      }
+      // Referral admin routes (auth required)
+      else if (path === '/api/admin/milestones' && request.method === 'GET') {
+        if (!isAuthorized(request, env)) {
+          response = new Response(
+            JSON.stringify({ success: false, error: 'Unauthorized' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } }
+          );
+        } else {
+          response = await handleGetMilestones(request, env);
+        }
+      } else if (path === '/api/admin/milestones' && request.method === 'POST') {
+        if (!isAuthorized(request, env)) {
+          response = new Response(
+            JSON.stringify({ success: false, error: 'Unauthorized' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } }
+          );
+        } else {
+          response = await handleCreateMilestone(request, env);
+        }
+      } else if (path.match(/^\/api\/admin\/milestones\/[^\/]+$/) && request.method === 'PUT') {
+        if (!isAuthorized(request, env)) {
+          response = new Response(
+            JSON.stringify({ success: false, error: 'Unauthorized' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } }
+          );
+        } else {
+          const id = path.replace('/api/admin/milestones/', '');
+          response = await handleUpdateMilestone(request, env, id);
+        }
+      } else if (path.match(/^\/api\/admin\/milestones\/[^\/]+$/) && request.method === 'DELETE') {
+        if (!isAuthorized(request, env)) {
+          response = new Response(
+            JSON.stringify({ success: false, error: 'Unauthorized' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } }
+          );
+        } else {
+          const id = path.replace('/api/admin/milestones/', '');
+          response = await handleDeleteMilestone(request, env, id);
+        }
+      } else if (path === '/api/admin/referral-stats' && request.method === 'GET') {
+        if (!isAuthorized(request, env)) {
+          response = new Response(
+            JSON.stringify({ success: false, error: 'Unauthorized' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } }
+          );
+        } else {
+          response = await handleGetReferralStats(request, env);
+        }
       }
       // Manual cron trigger endpoint for E2E testing
       else if (path === '/api/admin/trigger-cron' && request.method === 'POST') {

--- a/workers/newsletter/src/routes/referral.ts
+++ b/workers/newsletter/src/routes/referral.ts
@@ -1,0 +1,366 @@
+import type {
+  Env,
+  ApiResponse,
+  Subscriber,
+  ReferralMilestone,
+  ReferralAchievement,
+  ReferralDashboardResponse,
+  ReferralStatsResponse,
+  CreateMilestoneRequest,
+  UpdateMilestoneRequest,
+} from '../types';
+
+function jsonResponse<T>(data: T, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * GET /api/referral/dashboard/:referralCode
+ * Public endpoint to get referral dashboard data
+ */
+export async function handleGetReferralDashboard(
+  request: Request,
+  env: Env,
+  referralCode: string
+): Promise<Response> {
+  try {
+    // Find subscriber by referral code
+    const subscriber = await env.DB.prepare(
+      "SELECT * FROM subscribers WHERE referral_code = ? AND status = 'active'"
+    ).bind(referralCode).first<Subscriber>();
+
+    if (!subscriber) {
+      return jsonResponse<ApiResponse>(
+        { success: false, error: 'Invalid referral code' },
+        404
+      );
+    }
+
+    // Get achievements with milestone details
+    const achievementsResult = await env.DB.prepare(`
+      SELECT
+        a.id,
+        a.achieved_at,
+        m.name as milestone_name,
+        m.threshold,
+        m.reward_type,
+        m.reward_value
+      FROM referral_achievements a
+      JOIN referral_milestones m ON a.milestone_id = m.id
+      WHERE a.subscriber_id = ?
+      ORDER BY m.threshold ASC
+    `).bind(subscriber.id).all<{
+      id: string;
+      achieved_at: number;
+      milestone_name: string;
+      threshold: number;
+      reward_type: string | null;
+      reward_value: string | null;
+    }>();
+
+    const achievements = achievementsResult.results || [];
+
+    // Get next milestone
+    const nextMilestone = await env.DB.prepare(`
+      SELECT name, threshold
+      FROM referral_milestones
+      WHERE threshold > ?
+      ORDER BY threshold ASC
+      LIMIT 1
+    `).bind(subscriber.referral_count).first<{ name: string; threshold: number }>();
+
+    const response: ReferralDashboardResponse = {
+      referral_code: referralCode,
+      referral_link: `${env.SITE_URL}/newsletter?ref=${referralCode}`,
+      referral_count: subscriber.referral_count,
+      achievements: achievements.map(a => ({
+        id: a.id,
+        milestone_name: a.milestone_name,
+        threshold: a.threshold,
+        achieved_at: a.achieved_at,
+        reward_type: a.reward_type,
+        reward_value: a.reward_value,
+      })),
+    };
+
+    if (nextMilestone) {
+      response.next_milestone = {
+        name: nextMilestone.name,
+        threshold: nextMilestone.threshold,
+        remaining: nextMilestone.threshold - subscriber.referral_count,
+      };
+    }
+
+    return jsonResponse<ApiResponse<ReferralDashboardResponse>>({
+      success: true,
+      data: response,
+    });
+  } catch (error) {
+    console.error('Get referral dashboard error:', error);
+    return jsonResponse<ApiResponse>(
+      { success: false, error: 'Internal server error' },
+      500
+    );
+  }
+}
+
+/**
+ * GET /api/admin/milestones
+ * Get all milestones (admin only)
+ */
+export async function handleGetMilestones(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  try {
+    const result = await env.DB.prepare(
+      'SELECT * FROM referral_milestones ORDER BY threshold ASC'
+    ).all<ReferralMilestone>();
+
+    return jsonResponse<ApiResponse<ReferralMilestone[]>>({
+      success: true,
+      data: result.results || [],
+    });
+  } catch (error) {
+    console.error('Get milestones error:', error);
+    return jsonResponse<ApiResponse>(
+      { success: false, error: 'Internal server error' },
+      500
+    );
+  }
+}
+
+/**
+ * POST /api/admin/milestones
+ * Create a new milestone (admin only)
+ */
+export async function handleCreateMilestone(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  try {
+    const body = await request.json<CreateMilestoneRequest>();
+
+    if (!body.threshold || !body.name) {
+      return jsonResponse<ApiResponse>(
+        { success: false, error: 'threshold and name are required' },
+        400
+      );
+    }
+
+    if (body.threshold < 1) {
+      return jsonResponse<ApiResponse>(
+        { success: false, error: 'threshold must be at least 1' },
+        400
+      );
+    }
+
+    // Check for duplicate threshold
+    const existing = await env.DB.prepare(
+      'SELECT id FROM referral_milestones WHERE threshold = ?'
+    ).bind(body.threshold).first();
+
+    if (existing) {
+      return jsonResponse<ApiResponse>(
+        { success: false, error: 'A milestone with this threshold already exists' },
+        409
+      );
+    }
+
+    const id = crypto.randomUUID();
+    const now = Math.floor(Date.now() / 1000);
+
+    await env.DB.prepare(`
+      INSERT INTO referral_milestones (id, threshold, name, description, reward_type, reward_value, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      id,
+      body.threshold,
+      body.name,
+      body.description || null,
+      body.reward_type || null,
+      body.reward_value || null,
+      now
+    ).run();
+
+    const milestone = await env.DB.prepare(
+      'SELECT * FROM referral_milestones WHERE id = ?'
+    ).bind(id).first<ReferralMilestone>();
+
+    return jsonResponse<ApiResponse<ReferralMilestone>>(
+      { success: true, data: milestone! },
+      201
+    );
+  } catch (error) {
+    console.error('Create milestone error:', error);
+    return jsonResponse<ApiResponse>(
+      { success: false, error: 'Internal server error' },
+      500
+    );
+  }
+}
+
+/**
+ * PUT /api/admin/milestones/:id
+ * Update a milestone (admin only)
+ */
+export async function handleUpdateMilestone(
+  request: Request,
+  env: Env,
+  milestoneId: string
+): Promise<Response> {
+  try {
+    const existing = await env.DB.prepare(
+      'SELECT * FROM referral_milestones WHERE id = ?'
+    ).bind(milestoneId).first<ReferralMilestone>();
+
+    if (!existing) {
+      return jsonResponse<ApiResponse>(
+        { success: false, error: 'Milestone not found' },
+        404
+      );
+    }
+
+    const body = await request.json<UpdateMilestoneRequest>();
+
+    // Check for duplicate threshold if changing
+    if (body.threshold !== undefined && body.threshold !== existing.threshold) {
+      const duplicate = await env.DB.prepare(
+        'SELECT id FROM referral_milestones WHERE threshold = ? AND id != ?'
+      ).bind(body.threshold, milestoneId).first();
+
+      if (duplicate) {
+        return jsonResponse<ApiResponse>(
+          { success: false, error: 'A milestone with this threshold already exists' },
+          409
+        );
+      }
+    }
+
+    await env.DB.prepare(`
+      UPDATE referral_milestones
+      SET threshold = ?,
+          name = ?,
+          description = ?,
+          reward_type = ?,
+          reward_value = ?
+      WHERE id = ?
+    `).bind(
+      body.threshold ?? existing.threshold,
+      body.name ?? existing.name,
+      body.description ?? existing.description,
+      body.reward_type ?? existing.reward_type,
+      body.reward_value ?? existing.reward_value,
+      milestoneId
+    ).run();
+
+    const updated = await env.DB.prepare(
+      'SELECT * FROM referral_milestones WHERE id = ?'
+    ).bind(milestoneId).first<ReferralMilestone>();
+
+    return jsonResponse<ApiResponse<ReferralMilestone>>({
+      success: true,
+      data: updated!,
+    });
+  } catch (error) {
+    console.error('Update milestone error:', error);
+    return jsonResponse<ApiResponse>(
+      { success: false, error: 'Internal server error' },
+      500
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/milestones/:id
+ * Delete a milestone (admin only)
+ */
+export async function handleDeleteMilestone(
+  request: Request,
+  env: Env,
+  milestoneId: string
+): Promise<Response> {
+  try {
+    const existing = await env.DB.prepare(
+      'SELECT * FROM referral_milestones WHERE id = ?'
+    ).bind(milestoneId).first<ReferralMilestone>();
+
+    if (!existing) {
+      return jsonResponse<ApiResponse>(
+        { success: false, error: 'Milestone not found' },
+        404
+      );
+    }
+
+    // Delete related achievements first (cascade should handle this, but be explicit)
+    await env.DB.prepare(
+      'DELETE FROM referral_achievements WHERE milestone_id = ?'
+    ).bind(milestoneId).run();
+
+    await env.DB.prepare(
+      'DELETE FROM referral_milestones WHERE id = ?'
+    ).bind(milestoneId).run();
+
+    return jsonResponse<ApiResponse>({ success: true });
+  } catch (error) {
+    console.error('Delete milestone error:', error);
+    return jsonResponse<ApiResponse>(
+      { success: false, error: 'Internal server error' },
+      500
+    );
+  }
+}
+
+/**
+ * GET /api/admin/referral-stats
+ * Get referral statistics (admin only)
+ */
+export async function handleGetReferralStats(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  try {
+    // Total referrals
+    const totalResult = await env.DB.prepare(`
+      SELECT COALESCE(SUM(referral_count), 0) as total
+      FROM subscribers
+      WHERE status = 'active'
+    `).first<{ total: number }>();
+
+    // Active referrers (users with at least 1 referral)
+    const activeResult = await env.DB.prepare(`
+      SELECT COUNT(*) as count
+      FROM subscribers
+      WHERE status = 'active' AND referral_count > 0
+    `).first<{ count: number }>();
+
+    // Top referrers
+    const topResult = await env.DB.prepare(`
+      SELECT id, email, referral_count
+      FROM subscribers
+      WHERE status = 'active' AND referral_count > 0
+      ORDER BY referral_count DESC
+      LIMIT 10
+    `).all<{ id: string; email: string; referral_count: number }>();
+
+    const response: ReferralStatsResponse = {
+      total_referrals: totalResult?.total || 0,
+      active_referrers: activeResult?.count || 0,
+      top_referrers: topResult.results || [],
+    };
+
+    return jsonResponse<ApiResponse<ReferralStatsResponse>>({
+      success: true,
+      data: response,
+    });
+  } catch (error) {
+    console.error('Get referral stats error:', error);
+    return jsonResponse<ApiResponse>(
+      { success: false, error: 'Internal server error' },
+      500
+    );
+  }
+}

--- a/workers/newsletter/src/types.ts
+++ b/workers/newsletter/src/types.ts
@@ -22,6 +22,10 @@ export interface Subscriber {
   subscribed_at: number | null;
   unsubscribed_at: number | null;
   created_at: number;
+  // Referral program fields
+  referral_code: string | null;
+  referred_by: string | null;
+  referral_count: number;
 }
 
 export type CampaignStatus = 'draft' | 'scheduled' | 'sent' | 'failed';
@@ -86,6 +90,7 @@ export interface SubscribeRequest {
   turnstileToken: string;
   sequenceId?: string;
   signupPageSlug?: string;
+  ref?: string;  // Referral code
 }
 
 export interface BroadcastRequest {
@@ -363,4 +368,70 @@ export interface ArchiveDetailResponse {
   subject: string;
   content: string;
   published_at: number;
+}
+
+// Referral Program types
+export type RewardType = 'badge' | 'discount' | 'content' | 'custom';
+
+export interface ReferralMilestone {
+  id: string;
+  threshold: number;
+  name: string;
+  description: string | null;
+  reward_type: RewardType | null;
+  reward_value: string | null;
+  created_at: number;
+}
+
+export interface ReferralAchievement {
+  id: string;
+  subscriber_id: string;
+  milestone_id: string;
+  achieved_at: number;
+  notified_at: number | null;
+}
+
+export interface CreateMilestoneRequest {
+  threshold: number;
+  name: string;
+  description?: string;
+  reward_type?: RewardType;
+  reward_value?: string;
+}
+
+export interface UpdateMilestoneRequest {
+  threshold?: number;
+  name?: string;
+  description?: string;
+  reward_type?: RewardType;
+  reward_value?: string;
+}
+
+export interface ReferralDashboardResponse {
+  referral_code: string;
+  referral_link: string;
+  referral_count: number;
+  achievements: {
+    id: string;
+    milestone_name: string;
+    threshold: number;
+    achieved_at: number;
+    reward_type: string | null;
+    reward_value: string | null;
+  }[];
+  next_milestone?: {
+    name: string;
+    threshold: number;
+    remaining: number;
+  };
+}
+
+export interface ReferralStatsResponse {
+  total_referrals: number;
+  active_referrers: number;
+  top_referrers: {
+    id: string;
+    email: string;
+    referral_count: number;
+  }[];
 }


### PR DESCRIPTION
## Summary

ニュースレター購読者向けのリファラルプログラムを実装。購読者がリファラルリンクを共有し、マイルストーンに応じた報酬を獲得できる仕組み。

### 主な変更

**データベース:**
- `subscribers` テーブルに `referral_code`, `referred_by`, `referral_count` カラム追加
- `referral_milestones` テーブル（報酬閾値）
- `referral_achievements` テーブル（達成記録）

**API エンドポイント:**
- `GET /api/referral/dashboard/:code` - 公開ダッシュボード
- `GET/POST /api/admin/milestones` - マイルストーンCRUD
- `PUT/DELETE /api/admin/milestones/:id` - マイルストーン管理
- `GET /api/admin/referral-stats` - リファラル統計

**フロントエンド:**
- 確認ページにリファラルリンク・コード表示
- リファラルダッシュボード (`/newsletter/referrals/:code`)
- 管理画面 (`/admin/referrals`)

### 機能詳細

- メール確認時にリファラルコード自動生成（8文字）
- 紹介されたユーザーが確認すると紹介者カウント自動増加
- 閾値到達時にマイルストーン達成自動記録
- デフォルトマイルストーン: Bronze(3), Silver(10), Gold(25), Platinum(50)

## Test plan

- [x] ユニットテスト 10/10 パス
- [ ] 本番D1マイグレーション実行
- [ ] 本番動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)