### PR TITLE
fix: add missing routes for templates and brand-settings APIs

### DIFF
--- a/workers/newsletter/wrangler.toml
+++ b/workers/newsletter/wrangler.toml
@@ -72,6 +72,18 @@ zone_name = "edgeshift.tech"
 pattern = "edgeshift.tech/api/referral/*"
 zone_name = "edgeshift.tech"
 
+[[routes]]
+pattern = "edgeshift.tech/api/templates"
+zone_name = "edgeshift.tech"
+
+[[routes]]
+pattern = "edgeshift.tech/api/templates/*"
+zone_name = "edgeshift.tech"
+
+[[routes]]
+pattern = "edgeshift.tech/api/brand-settings"
+zone_name = "edgeshift.tech"
+
 [vars]
 ALLOWED_ORIGIN = "https://edgeshift.tech"
 SENDER_EMAIL = "newsletter@mail.edgeshift.tech"


### PR DESCRIPTION
## Summary

PR #61 でルート追加が漏れていた問題を修正。

- `/api/templates`
- `/api/templates/*`
- `/api/brand-settings`

Worker は既にデプロイ済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)