### PR TITLE
fix(admin): add logout button, fix signup page save, improve auth flow

### DIFF
--- a/src/components/admin/LogoutButton.tsx
+++ b/src/components/admin/LogoutButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { clearApiKey } from '../../utils/admin-api';
+
+export function LogoutButton() {
+  const handleLogout = () => {
+    clearApiKey();
+    window.location.href = '/admin';
+  };
+
+  return (
+    <button
+      onClick={handleLogout}
+      className="w-full px-4 py-2 text-left text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text)] rounded-lg transition-colors"
+    >
+      ログアウト
+    </button>
+  );
+}

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import { LogoutButton } from '../components/admin/LogoutButton';
 
 interface Props {
   title: string;
@@ -21,11 +22,11 @@ const fullTitle = `${title} | EdgeShift Admin`;
   <body class="min-h-screen bg-[var(--color-bg-secondary)]">
     <div class="flex min-h-screen">
       <!-- Sidebar - Light theme -->
-      <aside class="w-64 bg-[var(--color-bg)] border-r border-[var(--color-border)] flex-shrink-0">
+      <aside class="w-64 bg-[var(--color-bg)] border-r border-[var(--color-border)] flex-shrink-0 flex flex-col">
         <div class="p-4 border-b border-[var(--color-border)]">
           <a href="/admin" class="text-xl font-bold text-[var(--color-accent)]">EdgeShift Admin</a>
         </div>
-        <nav class="p-4">
+        <nav class="p-4 flex-1">
           <ul class="space-y-2">
             <li>
               <a href="/admin" class="block px-4 py-2 rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text)] transition-colors">
@@ -74,6 +75,9 @@ const fullTitle = `${title} | EdgeShift Admin`;
             </li>
           </ul>
         </nav>
+        <div class="p-4 border-t border-[var(--color-border)]">
+          <LogoutButton client:load />
+        </div>
       </aside>
 
       <!-- Main content -->

--- a/src/pages/admin/signup-pages/create.astro
+++ b/src/pages/admin/signup-pages/create.astro
@@ -1,5 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
+import { AuthProvider } from '../../../components/admin/AuthProvider';
 import { SignupPageEditForm } from '../../../components/admin/SignupPageEditForm';
 
 const url = new URL(Astro.request.url);
@@ -12,5 +13,7 @@ if (!pageType || (pageType !== 'landing' && pageType !== 'embed')) {
 ---
 
 <AdminLayout title="新しいページを作成">
-  <SignupPageEditForm client:load initialPageType={pageType} />
+  <AuthProvider client:load>
+    <SignupPageEditForm client:load initialPageType={pageType} />
+  </AuthProvider>
 </AdminLayout>

--- a/src/pages/admin/signup-pages/edit.astro
+++ b/src/pages/admin/signup-pages/edit.astro
@@ -1,5 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
+import { AuthProvider } from '../../../components/admin/AuthProvider';
 import { SignupPageEditForm } from '../../../components/admin/SignupPageEditForm';
 
 const url = new URL(Astro.request.url);
@@ -11,5 +12,7 @@ if (!pageId) {
 ---
 
 <AdminLayout title="ページを編集">
-  <SignupPageEditForm client:load pageId={pageId} />
+  <AuthProvider client:load>
+    <SignupPageEditForm client:load pageId={pageId} />
+  </AuthProvider>
 </AdminLayout>

--- a/src/pages/admin/signup-pages/index.astro
+++ b/src/pages/admin/signup-pages/index.astro
@@ -1,8 +1,11 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
+import { AuthProvider } from '../../../components/admin/AuthProvider';
 import { SignupPageList } from '../../../components/admin/SignupPageList';
 ---
 
 <AdminLayout title="登録ページ管理">
-  <SignupPageList client:load />
+  <AuthProvider client:load>
+    <SignupPageList client:load />
+  </AuthProvider>
 </AdminLayout>

--- a/workers/newsletter/src/__tests__/signup-pages.test.ts
+++ b/workers/newsletter/src/__tests__/signup-pages.test.ts
@@ -119,5 +119,43 @@ describe('Signup Pages API', () => {
       // Try to create duplicate
       await expect(createSignupPage(env, page)).rejects.toThrow('Slug already exists');
     });
+
+    it('should reject non-existent contact_list_id', async () => {
+      const env = getTestEnv();
+      const { createSignupPage } = await import('../routes/signup-pages');
+
+      const newPage = {
+        slug: 'test-contact-list',
+        title: 'Test',
+        content: '<p>Test</p>',
+        contact_list_id: 'non-existent-id',
+      };
+
+      await expect(createSignupPage(env, newPage)).rejects.toThrow('Contact list not found');
+    });
+
+    it('should accept valid contact_list_id', async () => {
+      const env = getTestEnv();
+      const { createSignupPage } = await import('../routes/signup-pages');
+      const { createContactList } = await import('../routes/contact-lists');
+
+      // Create a valid contact list first
+      const contactList = await createContactList(env, {
+        name: 'Test List',
+        description: 'Test description',
+      });
+
+      const newPage = {
+        slug: 'test-with-list',
+        title: 'Test with List',
+        content: '<p>Test</p>',
+        contact_list_id: contactList.id,
+      };
+
+      const result = await createSignupPage(env, newPage);
+
+      expect(result.id).toBeTruthy();
+      expect(result.contact_list_id).toBe(contactList.id);
+    });
   });
 });

--- a/workers/newsletter/src/routes/signup-pages.ts
+++ b/workers/newsletter/src/routes/signup-pages.ts
@@ -167,6 +167,19 @@ export async function createSignupPage(env: Env, input: SignupPageInput): Promis
     }
   }
 
+  // Validate contact_list_id if provided
+  if (input.contact_list_id) {
+    const contactList = await env.DB.prepare(
+      'SELECT id FROM contact_lists WHERE id = ?'
+    )
+      .bind(input.contact_list_id)
+      .first();
+
+    if (!contactList) {
+      throw new Error('Contact list not found');
+    }
+  }
+
   // Generate ID
   const id = crypto.randomUUID();
   const now = Math.floor(Date.now() / 1000);
@@ -291,6 +304,19 @@ export async function updateSignupPage(
 
     if (!sequence) {
       throw new Error('Sequence not found');
+    }
+  }
+
+  // Validate contact_list_id if provided
+  if (input.contact_list_id) {
+    const contactList = await env.DB.prepare(
+      'SELECT id FROM contact_lists WHERE id = ?'
+    )
+      .bind(input.contact_list_id)
+      .first();
+
+    if (!contactList) {
+      throw new Error('Contact list not found');
     }
   }
 
@@ -547,7 +573,8 @@ export async function handleCreateSignupPage(
         error.message.includes('Missing required') ||
         error.message.includes('already exists') ||
         error.message.includes('Content size exceeds') ||
-        error.message.includes('Sequence not found')
+        error.message.includes('Sequence not found') ||
+        error.message.includes('Contact list not found')
       ) {
         return errorResponse(error.message, 400);
       }
@@ -585,7 +612,8 @@ export async function handleUpdateSignupPage(
         error.message.includes('Invalid slug') ||
         error.message.includes('already exists') ||
         error.message.includes('Content size exceeds') ||
-        error.message.includes('Sequence not found')
+        error.message.includes('Sequence not found') ||
+        error.message.includes('Contact list not found')
       ) {
         return errorResponse(error.message, 400);
       }


### PR DESCRIPTION
## Summary

ユーザーテスト Cycle 1 で発見された UI 問題の修正:

- **Issue 003**: Admin サイドバーにログアウトボタンを追加
- **Issue 007**: サインアップページ保存時の Internal Server Error を修正（contact_list_id バリデーション追加）
- **Issue 002**: signup-pages に AuthProvider ラッパーを追加し、認証フローを改善

## Changes

| File | Change |
|------|--------|
| `src/components/admin/LogoutButton.tsx` | 新規作成 - ログアウトボタンコンポーネント |
| `src/layouts/AdminLayout.astro` | サイドバー下部にログアウトボタン追加 |
| `workers/newsletter/src/routes/signup-pages.ts` | contact_list_id バリデーション追加 |
| `workers/newsletter/src/__tests__/signup-pages.test.ts` | バリデーションテスト追加 |
| `src/pages/admin/signup-pages/*.astro` | AuthProvider ラッパー追加 |

## Test plan

- [x] `npm run build` - ビルド成功
- [x] `npm test` - 349 テスト全てパス
- [ ] 手動確認: /admin でログアウトボタン表示確認
- [ ] 手動確認: サインアップページ保存が正常に動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)