### PR TITLE
fix(api): normalize apiRequest response format for all endpoints

### DIFF
--- a/src/components/admin/AuthProvider.tsx
+++ b/src/components/admin/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, createContext, useContext, type ReactNode } from 'react';
+import { useState, useEffect, useCallback, createContext, useContext, type ReactNode } from 'react';
 import { isAuthenticated, clearApiKey, apiRequest } from '../../utils/admin-api';
 
 interface AuthContextType {
@@ -25,7 +25,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const verifyAuth = () => {
+  const verifyAuth = useCallback(() => {
     setLoading(true);
     setError(null);
 
@@ -39,6 +39,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         } else if (result.error?.includes('Authentication failed') || result.error === 'Not authenticated') {
           // 401 error or invalid/empty key - clear and redirect to login
           clearApiKey();
+          setAuthenticated(false);
           setLoading(false);
           window.location.href = '/auth/login?error=unauthorized';
         } else {
@@ -49,14 +50,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
       });
     } else {
       // Not authenticated, redirect to Magic Link login
+      setAuthenticated(false);
       setLoading(false);
       window.location.href = '/auth/login?error=unauthorized';
     }
-  };
+  }, []);
 
   useEffect(() => {
     verifyAuth();
-  }, []);
+  }, [verifyAuth]);
 
   const logout = () => {
     clearApiKey();

--- a/src/utils/admin-api.ts
+++ b/src/utils/admin-api.ts
@@ -58,8 +58,15 @@ export async function apiRequest<T>(
 
     // Normalize response format: some endpoints (e.g., AI) return raw data
     // while others return { success: true, data }
-    if (typeof data === 'object' && data !== null && 'success' in data) {
-      return data;
+    if (typeof data === 'object' && data !== null) {
+      // Already in standard format
+      if ('success' in data) {
+        return data;
+      }
+      // Check for error field in 200 response (some endpoints return { error: ... } with 200)
+      if ('error' in data && typeof data.error === 'string') {
+        return { success: false, error: data.error };
+      }
     }
     return { success: true, data };
   } catch (error) {


### PR DESCRIPTION
## Summary
- AI endpoints return raw data (`{ subjects: [...] }`) while Newsletter Worker returns wrapped format (`{ success: true, data: {...} }`)
- Added normalization logic to detect and wrap raw responses
- **Fixes Issue 009**: all API calls now consistently return `{ success: true, data }` format

## Root Cause Analysis
- Newsletter Worker uses `successResponse()` which wraps data in `{ success: true, data }`
- AI endpoints (edgeshift-premium) return raw data directly
- Frontend expects `result.success && result.data` pattern
- Without normalization, AI endpoint calls fail the check

## Test Plan
- [ ] Verify Dashboard loads correctly
- [ ] Verify AI content generation works
- [ ] Verify sequence/campaign CRUD operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)