### PR TITLE
fix(auth): add Accept header to authRequest function

### DIFF
--- a/src/utils/auth-api.ts
+++ b/src/utils/auth-api.ts
@@ -50,6 +50,7 @@ async function authRequest<T>(
       method,
       headers: {
         'Content-Type': 'application/json',
+        'Accept': 'application/json', // Request JSON response from API
       },
       credentials: 'include', // Include HTTPOnly cookies
       body: body ? JSON.stringify(body) : undefined,


### PR DESCRIPTION
## Summary
- Add `Accept: application/json` header to `authRequest()` function in `auth-api.ts`
- Ensures all auth API calls (getCurrentUser, setupTOTP, verifyTOTP, logout) request JSON responses

## Context
Codex review identified that `authRequest()` was missing the Accept header, which could cause the API to return HTML instead of JSON.

## Test plan
- [ ] Verify auth flows work correctly with session authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)