### PR TITLE
fix(admin): call logout API to clear session cookie

### DIFF
--- a/src/components/admin/LogoutButton.tsx
+++ b/src/components/admin/LogoutButton.tsx
@@ -1,11 +1,18 @@
 'use client';
 
 import { clearApiKey } from '../../utils/admin-api';
+import { logout as logoutApi } from '../../utils/auth-api';
 
 export function LogoutButton() {
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    // Clear API key from localStorage
     clearApiKey();
-    window.location.href = '/admin';
+    try {
+      await logoutApi();
+    } finally {
+      // Always redirect, even if logoutApi fails (network error)
+      window.location.href = '/auth/login';
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- LogoutButton was only clearing API key from localStorage but not calling the session logout API
- Session cookie remained intact, causing user to stay logged in after clicking logout
- Now calls `/api/premium/auth/logout` and redirects to `/auth/login`

## Test plan
- [ ] Login to admin with session (Magic Link + TOTP)
- [ ] Click logout button in sidebar
- [ ] Verify redirect to /auth/login
- [ ] Verify session is cleared (cannot access /admin without re-login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)