### PR TITLE
fix: use async auth check for campaign send/stats endpoints

### DIFF
--- a/workers/newsletter/src/routes/campaign-send.ts
+++ b/workers/newsletter/src/routes/campaign-send.ts
@@ -1,5 +1,5 @@
 import type { Env, Campaign, Subscriber, BrandSettings } from '../types';
-import { isAuthorized } from '../lib/auth';
+import { isAuthorizedAsync } from '../lib/auth';
 import { sendBatchEmails } from '../lib/email';
 import { recordDeliveryLogs, getDeliveryStats } from '../lib/delivery';
 import { errorResponse, successResponse } from '../lib/response';
@@ -10,7 +10,7 @@ export async function sendCampaign(
   env: Env,
   campaignId: string
 ): Promise<Response> {
-  if (!isAuthorized(request, env)) {
+  if (!(await isAuthorizedAsync(request, env))) {
     return errorResponse('Unauthorized', 401);
   }
 
@@ -126,7 +126,7 @@ export async function getCampaignStats(
   env: Env,
   campaignId: string
 ): Promise<Response> {
-  if (!isAuthorized(request, env)) {
+  if (!(await isAuthorizedAsync(request, env))) {
     return errorResponse('Unauthorized', 401);
   }
 


### PR DESCRIPTION
## Summary
- Replace `isAuthorized()` with `isAuthorizedAsync()` in campaign-send.ts
- Fixes 401 Unauthorized errors when sending campaigns from admin dashboard via Cloudflare Access

## Root Cause
The synchronous `isAuthorized()` function only checks API key authentication. Admin dashboard users authenticate via Cloudflare Access (JWT), which requires the async `isAuthorizedAsync()` function.

## Test plan
- [x] Unit tests pass (8/8)
- [ ] Verify campaign send works from admin dashboard after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)