### PR TITLE
feat: optimize email typography for Japanese readability

### DIFF
--- a/changelogs.md
+++ b/changelogs.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## 2026-01-14
+
+### feat: Japanese typography optimization for email templates
+
+日本語メールの可読性向上のため、フォントとタイポグラフィを最適化。
+
+**変更内容:**
+- 共通スタイル定数ファイル `styles.ts` を新規作成
+- 全メールテンプレートに日本語フォントスタックを適用
+- 行間・文字間隔を日本語向けに調整
+
+**適用されたスタイル:**
+| 項目 | Before | After |
+|------|--------|-------|
+| font-family | システムフォントのみ | 日本語フォント追加（Hiragino, Meiryo） |
+| font-size (本文) | 未指定 | 16px |
+| line-height | 1.6 | 1.8 |
+| letter-spacing | なし | 0.02em |
+
+**更新ファイル:**
+- `workers/newsletter/src/lib/templates/styles.ts` (新規)
+- `workers/newsletter/src/lib/templates/presets/*.ts` (5ファイル)
+- `workers/newsletter/src/routes/subscribe.ts`
+- `workers/newsletter/src/routes/broadcast.ts`
+- `workers/newsletter/src/scheduled.ts`
+
+---
+
+### fix: campaign send auth - use async auth check
+
+キャンペーン送信時の401エラーを修正。
+
+**原因:** `campaign-send.ts` で同期版 `isAuthorized()` を使用しており、CF Access 認証に対応していなかった。
+
+**修正:** `isAuthorizedAsync()` に変更し、API Key + CF Access + Session Cookie 全てに対応。
+
+**更新ファイル:**
+- `workers/newsletter/src/routes/campaign-send.ts`

--- a/workers/newsletter/src/lib/templates/presets/announcement.ts
+++ b/workers/newsletter/src/lib/templates/presets/announcement.ts
@@ -1,5 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
+import { STYLES } from '../styles';
 
 export function renderAnnouncement(options: PresetRenderOptions): string {
   const { content, subject, brandSettings, unsubscribeUrl, siteUrl } = options;
@@ -11,15 +12,15 @@ export function renderAnnouncement(options: PresetRenderOptions): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: ${brandSettings.secondary_color}; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body(brandSettings.secondary_color)}">
   <div style="background-color: ${brandSettings.primary_color}; color: white; padding: 24px; text-align: center; border-radius: 8px; margin-bottom: 24px;">
-    <h1 style="margin: 0; font-size: 28px;">📢 ${subject}</h1>
+    <h1 style="${STYLES.headingLarge('white')}">📢 ${subject}</h1>
   </div>
-  <div style="margin-bottom: 32px; padding: 0 16px;">
+  <div style="${STYLES.content} padding: 0 16px;">
     ${content}
   </div>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <hr style="${STYLES.hr}">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: ${brandSettings.primary_color};">${brandSettings.footer_text}</a><br>
     <a href="${unsubscribeUrl}" style="color: #a3a3a3;">配信停止はこちら</a>
   </p>

--- a/workers/newsletter/src/lib/templates/presets/newsletter.ts
+++ b/workers/newsletter/src/lib/templates/presets/newsletter.ts
@@ -1,5 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
+import { STYLES } from '../styles';
 
 export function renderNewsletter(options: PresetRenderOptions): string {
   const { content, subject, brandSettings, unsubscribeUrl, siteUrl } = options;
@@ -15,16 +16,16 @@ export function renderNewsletter(options: PresetRenderOptions): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: ${brandSettings.secondary_color}; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body(brandSettings.secondary_color)}">
   <div style="text-align: center; margin-bottom: 32px;">
     ${logoHtml}
-    <h1 style="color: ${brandSettings.secondary_color}; font-size: 24px; margin: 0;">${subject}</h1>
+    <h1 style="${STYLES.heading(brandSettings.secondary_color)}">${subject}</h1>
   </div>
-  <div style="margin-bottom: 32px;">
+  <div style="${STYLES.content}">
     ${content}
   </div>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <hr style="${STYLES.hr}">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: ${brandSettings.primary_color};">${brandSettings.footer_text}</a><br>
     <a href="${unsubscribeUrl}" style="color: #a3a3a3;">配信停止はこちら</a>
   </p>

--- a/workers/newsletter/src/lib/templates/presets/product-update.ts
+++ b/workers/newsletter/src/lib/templates/presets/product-update.ts
@@ -1,5 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
+import { STYLES } from '../styles';
 
 export function renderProductUpdate(options: PresetRenderOptions): string {
   const { content, subject, brandSettings, unsubscribeUrl, siteUrl } = options;
@@ -15,17 +16,17 @@ export function renderProductUpdate(options: PresetRenderOptions): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: ${brandSettings.secondary_color}; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body(brandSettings.secondary_color)}">
   <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 24px; padding-bottom: 16px; border-bottom: 2px solid ${brandSettings.primary_color};">
     ${logoHtml}
-    <span style="background-color: ${brandSettings.primary_color}; color: white; padding: 4px 12px; border-radius: 12px; font-size: 12px;">UPDATE</span>
+    <span style="${STYLES.badge(brandSettings.primary_color)}">UPDATE</span>
   </div>
-  <h1 style="font-size: 24px; color: ${brandSettings.secondary_color}; margin-bottom: 24px;">🚀 ${subject}</h1>
-  <div style="margin-bottom: 32px;">
+  <h1 style="${STYLES.heading(brandSettings.secondary_color)} margin-bottom: 24px;">🚀 ${subject}</h1>
+  <div style="${STYLES.content}">
     ${content}
   </div>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <hr style="${STYLES.hr}">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: ${brandSettings.primary_color};">${brandSettings.footer_text}</a><br>
     <a href="${unsubscribeUrl}" style="color: #a3a3a3;">配信停止はこちら</a>
   </p>

--- a/workers/newsletter/src/lib/templates/presets/simple.ts
+++ b/workers/newsletter/src/lib/templates/presets/simple.ts
@@ -1,4 +1,5 @@
 import type { BrandSettings } from '../../../types';
+import { STYLES } from '../styles';
 
 export interface PresetRenderOptions {
   content: string;
@@ -20,15 +21,15 @@ export function renderSimple(options: PresetRenderOptions): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: ${brandSettings.secondary_color}; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body(brandSettings.secondary_color)}">
   <div style="margin-bottom: 16px;">
     ${greeting}
   </div>
-  <div style="margin-bottom: 32px;">
+  <div style="${STYLES.content}">
     ${content}
   </div>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <hr style="${STYLES.hr}">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: ${brandSettings.primary_color};">${brandSettings.footer_text}</a><br>
     <a href="${unsubscribeUrl}" style="color: #a3a3a3;">配信停止はこちら</a>
   </p>

--- a/workers/newsletter/src/lib/templates/presets/welcome.ts
+++ b/workers/newsletter/src/lib/templates/presets/welcome.ts
@@ -1,5 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
+import { STYLES } from '../styles';
 
 export function renderWelcome(options: PresetRenderOptions): string {
   const { content, brandSettings, subscriberName, unsubscribeUrl, siteUrl } = options;
@@ -12,16 +13,16 @@ export function renderWelcome(options: PresetRenderOptions): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: ${brandSettings.secondary_color}; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body(brandSettings.secondary_color)}">
   <div style="text-align: center; margin-bottom: 32px;">
-    <h1 style="color: ${brandSettings.primary_color}; font-size: 28px; margin-bottom: 8px;">🎉 ようこそ！</h1>
-    <p style="font-size: 18px; color: ${brandSettings.secondary_color};">${name}さん、ご登録ありがとうございます</p>
+    <h1 style="${STYLES.headingLarge(brandSettings.primary_color)} margin-bottom: 8px;">🎉 ようこそ！</h1>
+    <p style="${STYLES.subheading(brandSettings.secondary_color)}">${name}さん、ご登録ありがとうございます</p>
   </div>
-  <div style="margin-bottom: 32px; background-color: #f9fafb; padding: 24px; border-radius: 8px;">
+  <div style="${STYLES.content} background-color: #f9fafb; padding: 24px; border-radius: 8px;">
     ${content}
   </div>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <hr style="${STYLES.hr}">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: ${brandSettings.primary_color};">${brandSettings.footer_text}</a><br>
     <a href="${unsubscribeUrl}" style="color: #a3a3a3;">配信停止はこちら</a>
   </p>

--- a/workers/newsletter/src/lib/templates/styles.ts
+++ b/workers/newsletter/src/lib/templates/styles.ts
@@ -1,0 +1,85 @@
+/**
+ * Common email styles optimized for Japanese typography
+ *
+ * Best practices for Japanese email:
+ * - Include Japanese fonts in font-family stack
+ * - Use larger line-height (1.7-1.8) for readability
+ * - Add slight letter-spacing for dense Japanese text
+ * - Minimum font-size 16px for body text (mobile readability)
+ */
+
+/**
+ * Font stack optimized for Japanese + cross-platform
+ * Priority: Apple (Mac/iOS) -> Windows -> fallback
+ */
+export const FONT_FAMILY = [
+  '-apple-system',
+  'BlinkMacSystemFont',
+  "'Hiragino Kaku Gothic ProN'",
+  "'Hiragino Sans'",
+  'Meiryo',
+  "'Segoe UI'",
+  'sans-serif',
+].join(', ');
+
+/**
+ * Typography settings
+ */
+export const TYPOGRAPHY = {
+  body: {
+    fontSize: '16px',
+    lineHeight: '1.8',
+    letterSpacing: '0.02em',
+  },
+  heading: {
+    fontSize: '24px',
+    lineHeight: '1.4',
+    letterSpacing: '0.01em',
+  },
+  small: {
+    fontSize: '14px',
+    lineHeight: '1.6',
+  },
+  footer: {
+    fontSize: '12px',
+    lineHeight: '1.5',
+  },
+} as const;
+
+/**
+ * Pre-built inline style strings for common elements
+ */
+export const STYLES = {
+  /** Body element style */
+  body: (textColor: string) =>
+    `font-family: ${FONT_FAMILY}; font-size: ${TYPOGRAPHY.body.fontSize}; line-height: ${TYPOGRAPHY.body.lineHeight}; letter-spacing: ${TYPOGRAPHY.body.letterSpacing}; color: ${textColor}; max-width: 600px; margin: 0 auto; padding: 20px;`,
+
+  /** Main heading (h1) style */
+  heading: (textColor: string) =>
+    `font-size: ${TYPOGRAPHY.heading.fontSize}; line-height: ${TYPOGRAPHY.heading.lineHeight}; letter-spacing: ${TYPOGRAPHY.heading.letterSpacing}; color: ${textColor}; margin: 0;`,
+
+  /** Large heading for announcements */
+  headingLarge: (textColor: string) =>
+    `font-size: 28px; line-height: ${TYPOGRAPHY.heading.lineHeight}; color: ${textColor}; margin: 0;`,
+
+  /** Subheading style */
+  subheading: (textColor: string) =>
+    `font-size: 18px; line-height: 1.5; color: ${textColor};`,
+
+  /** Footer text style */
+  footer: `color: #a3a3a3; font-size: ${TYPOGRAPHY.footer.fontSize}; line-height: ${TYPOGRAPHY.footer.lineHeight}; text-align: center;`,
+
+  /** Small/secondary text style */
+  small: (textColor: string) =>
+    `color: ${textColor}; font-size: ${TYPOGRAPHY.small.fontSize}; line-height: ${TYPOGRAPHY.small.lineHeight};`,
+
+  /** Horizontal rule */
+  hr: 'border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;',
+
+  /** Content wrapper */
+  content: 'margin-bottom: 32px;',
+
+  /** Badge/label style */
+  badge: (bgColor: string) =>
+    `background-color: ${bgColor}; color: white; padding: 4px 12px; border-radius: 12px; font-size: 12px;`,
+} as const;

--- a/workers/newsletter/src/routes/broadcast.ts
+++ b/workers/newsletter/src/routes/broadcast.ts
@@ -1,6 +1,7 @@
 import type { Env, BroadcastRequest, ApiResponse, Subscriber } from '../types';
 import { isAuthorizedAsync } from '../lib/auth';
 import { sendBatchEmails } from '../lib/email';
+import { STYLES } from '../lib/templates/styles';
 
 function buildNewsletterEmail(
   content: string,
@@ -14,18 +15,18 @@ function buildNewsletterEmail(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1e1e1e; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body('#1e1e1e')}">
   <div style="text-align: center; margin-bottom: 32px;">
-    <h1 style="color: #1e1e1e; font-size: 24px; margin: 0;">EdgeShift Newsletter</h1>
+    <h1 style="${STYLES.heading('#1e1e1e')}">EdgeShift Newsletter</h1>
   </div>
 
-  <div style="margin-bottom: 32px;">
+  <div style="${STYLES.content}">
     ${content}
   </div>
 
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
+  <hr style="${STYLES.hr}">
 
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: #7c3aed;">EdgeShift</a><br>
     <a href="${unsubscribeUrl}" style="color: #a3a3a3;">配信停止はこちら</a>
   </p>

--- a/workers/newsletter/src/routes/subscribe.ts
+++ b/workers/newsletter/src/routes/subscribe.ts
@@ -3,6 +3,7 @@ import { verifyTurnstileToken } from '../lib/turnstile';
 import { sendEmail } from '../lib/email';
 import { checkRateLimit } from '../lib/rate-limiter';
 import { isDisposableEmail } from '../lib/disposable-emails';
+import { STYLES } from '../lib/templates/styles';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -46,9 +47,9 @@ function buildConfirmationEmail(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>メールアドレスの確認</title>
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1e1e1e; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body('#1e1e1e')}">
   <div style="text-align: center; margin-bottom: 32px;">
-    <h1 style="color: #1e1e1e; font-size: 24px; margin: 0;">EdgeShift Newsletter</h1>
+    <h1 style="${STYLES.heading('#1e1e1e')}">EdgeShift Newsletter</h1>
   </div>
 
   <p>${greeting}、</p>
@@ -61,13 +62,13 @@ function buildConfirmationEmail(
     <a href="${confirmUrl}" style="display: inline-block; background-color: #7c3aed; color: white; text-decoration: none; padding: 12px 32px; border-radius: 8px; font-weight: 500;">メールアドレスを確認する</a>
   </div>
 
-  <p style="color: #525252; font-size: 14px;">このリンクは24時間有効です。</p>
+  <p style="${STYLES.small('#525252')}">このリンクは24時間有効です。</p>
 
-  <p style="color: #525252; font-size: 14px;">もし心当たりがない場合は、このメールを無視してください。</p>
+  <p style="${STYLES.small('#525252')}">もし心当たりがない場合は、このメールを無視してください。</p>
 
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
+  <hr style="${STYLES.hr}">
 
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: #7c3aed;">EdgeShift</a>
   </p>
 </body>

--- a/workers/newsletter/src/scheduled.ts
+++ b/workers/newsletter/src/scheduled.ts
@@ -3,6 +3,7 @@ import { sendBatchEmails, sendEmail } from './lib/email';
 import { recordDeliveryLogs } from './lib/delivery';
 import { processSequenceEmails } from './lib/sequence-processor';
 import { sendAbTest, sendAbTestWinner, type SendEmailFn } from './routes/ab-test-send';
+import { STYLES } from './lib/templates/styles';
 
 /**
  * Convert plain text URLs to clickable links
@@ -28,15 +29,15 @@ function buildNewsletterEmail(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1e1e1e; max-width: 600px; margin: 0 auto; padding: 20px;">
+<body style="${STYLES.body('#1e1e1e')}">
   <div style="text-align: center; margin-bottom: 32px;">
-    <h1 style="color: #1e1e1e; font-size: 24px; margin: 0;">EdgeShift Newsletter</h1>
+    <h1 style="${STYLES.heading('#1e1e1e')}">EdgeShift Newsletter</h1>
   </div>
-  <div style="margin-bottom: 32px;">
+  <div style="${STYLES.content}">
     ${linkifyUrls(content)}
   </div>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;">
-  <p style="color: #a3a3a3; font-size: 12px; text-align: center;">
+  <hr style="${STYLES.hr}">
+  <p style="${STYLES.footer}">
     <a href="${siteUrl}" style="color: #7c3aed;">EdgeShift</a><br>
     <a href="${unsubscribeUrl}" style="color: #a3a3a3;">配信停止はこちら</a>
   </p>


### PR DESCRIPTION
## Summary
- Add shared `styles.ts` with Japanese font stack and typography settings
- Apply Japanese fonts (Hiragino, Meiryo) to all email templates
- Optimize line-height (1.8) and letter-spacing (0.02em) for Japanese text

## Changes
| Setting | Before | After |
|---------|--------|-------|
| font-family | System fonts only | + Hiragino, Meiryo |
| font-size | Unspecified | 16px |
| line-height | 1.6 | 1.8 |
| letter-spacing | None | 0.02em |

## Test plan
- [x] All 349 tests pass
- [ ] Send test email and verify typography

🤖 Generated with [Claude Code](https://claude.ai/code)