### PR TITLE
fix(newsletter): reduce list indent and item spacing

### DIFF
--- a/workers/newsletter/src/lib/templates/presets/announcement.ts
+++ b/workers/newsletter/src/lib/templates/presets/announcement.ts
@@ -1,6 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
-import { STYLES, COLORS, wrapInEmailLayout } from '../styles';
+import { STYLES, COLORS, wrapInEmailLayout, applyListStyles } from '../styles';
 
 export function renderAnnouncement(options: PresetRenderOptions): string {
   const { content, subject, brandSettings, unsubscribeUrl, siteUrl } = options;
@@ -10,7 +10,7 @@ export function renderAnnouncement(options: PresetRenderOptions): string {
       <h1 style="${STYLES.headingLarge('white')}">📢 ${subject}</h1>
     </div>
     <div style="${STYLES.content}">
-      ${content}
+      ${applyListStyles(content)}
     </div>
     <div style="${STYLES.footerWrapper}">
       <p style="${STYLES.footer}">

--- a/workers/newsletter/src/lib/templates/presets/newsletter.ts
+++ b/workers/newsletter/src/lib/templates/presets/newsletter.ts
@@ -1,6 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
-import { STYLES, COLORS, wrapInEmailLayout } from '../styles';
+import { STYLES, COLORS, wrapInEmailLayout, applyListStyles } from '../styles';
 
 export function renderNewsletter(options: PresetRenderOptions): string {
   const { content, subject, brandSettings, unsubscribeUrl, siteUrl } = options;
@@ -15,7 +15,7 @@ export function renderNewsletter(options: PresetRenderOptions): string {
       <h1 style="${STYLES.heading(brandSettings.secondary_color)}">${subject}</h1>
     </div>
     <div style="${STYLES.content}">
-      ${content}
+      ${applyListStyles(content)}
     </div>
     <div style="${STYLES.footerWrapper}">
       <p style="${STYLES.footer}">

--- a/workers/newsletter/src/lib/templates/presets/product-update.ts
+++ b/workers/newsletter/src/lib/templates/presets/product-update.ts
@@ -1,6 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
-import { STYLES, COLORS, wrapInEmailLayout } from '../styles';
+import { STYLES, COLORS, wrapInEmailLayout, applyListStyles } from '../styles';
 
 export function renderProductUpdate(options: PresetRenderOptions): string {
   const { content, subject, brandSettings, unsubscribeUrl, siteUrl } = options;
@@ -16,7 +16,7 @@ export function renderProductUpdate(options: PresetRenderOptions): string {
     </div>
     <h1 style="${STYLES.heading(brandSettings.secondary_color)}">🚀 ${subject}</h1>
     <div style="${STYLES.content}">
-      ${content}
+      ${applyListStyles(content)}
     </div>
     <div style="${STYLES.footerWrapper}">
       <p style="${STYLES.footer}">

--- a/workers/newsletter/src/lib/templates/presets/simple.ts
+++ b/workers/newsletter/src/lib/templates/presets/simple.ts
@@ -1,5 +1,5 @@
 import type { BrandSettings } from '../../../types';
-import { STYLES, COLORS, wrapInEmailLayout } from '../styles';
+import { STYLES, COLORS, wrapInEmailLayout, applyListStyles } from '../styles';
 
 export interface PresetRenderOptions {
   content: string;
@@ -15,7 +15,7 @@ export function renderSimple(options: PresetRenderOptions): string {
 
   const innerContent = `
     <div style="${STYLES.content}">
-      ${content}
+      ${applyListStyles(content)}
     </div>
     <div style="${STYLES.footerWrapper}">
       <p style="${STYLES.footer}">

--- a/workers/newsletter/src/lib/templates/presets/welcome.ts
+++ b/workers/newsletter/src/lib/templates/presets/welcome.ts
@@ -1,6 +1,6 @@
 import type { BrandSettings } from '../../../types';
 import type { PresetRenderOptions } from './simple';
-import { STYLES, COLORS, wrapInEmailLayout } from '../styles';
+import { STYLES, COLORS, wrapInEmailLayout, applyListStyles } from '../styles';
 
 export function renderWelcome(options: PresetRenderOptions): string {
   const { content, brandSettings, subscriberName, unsubscribeUrl, siteUrl } = options;
@@ -14,7 +14,7 @@ export function renderWelcome(options: PresetRenderOptions): string {
       <p style="${STYLES.subheading(brandSettings.secondary_color)}">${name}さん、ご登録ありがとうございます</p>
     </div>
     <div style="${STYLES.content} background-color: #f9fafb; padding: 24px; border-radius: 8px;">
-      ${content}
+      ${applyListStyles(content)}
     </div>
     <div style="${STYLES.footerWrapper}">
       <p style="${STYLES.footer}">

--- a/workers/newsletter/src/lib/templates/styles.ts
+++ b/workers/newsletter/src/lib/templates/styles.ts
@@ -45,7 +45,7 @@ export const SPACING = {
   boxPaddingMobile: '24px',
   sectionGap: '24px',
   paragraphGap: '16px',
-  listItemGap: '8px',
+  listItemGap: '4px',
 } as const;
 
 /**
@@ -122,7 +122,7 @@ export const STYLES = {
   content: `margin-bottom: ${SPACING.sectionGap};`,
 
   /** List styles (ol/ul) */
-  list: `margin: 0 0 ${SPACING.paragraphGap} 0; padding-left: 24px;`,
+  list: `margin: 0 0 ${SPACING.paragraphGap} 0; padding-left: 16px;`,
 
   /** List item style */
   listItem: `margin-bottom: ${SPACING.listItemGap};`,
@@ -150,6 +150,18 @@ export const STYLES = {
   /** YouTube link wrapper */
   youtubeLink: `display: block; margin: ${SPACING.sectionGap} 0; text-decoration: none;`,
 } as const;
+
+/**
+ * Apply inline styles to list elements (ul, ol, li)
+ * Email clients don't support <style> tags, so inline styles are required
+ */
+export function applyListStyles(html: string): string {
+  return html
+    // Apply list (ul/ol) styles
+    .replace(/<(ul|ol)(?![^>]*style=)/gi, `<$1 style="${STYLES.list}"`)
+    // Apply list item styles
+    .replace(/<li(?![^>]*style=)/gi, `<li style="${STYLES.listItem}"`);
+}
 
 /**
  * Generate full email HTML structure with gray background + white box

--- a/workers/newsletter/src/routes/broadcast.ts
+++ b/workers/newsletter/src/routes/broadcast.ts
@@ -1,7 +1,7 @@
 import type { Env, BroadcastRequest, ApiResponse, Subscriber } from '../types';
 import { isAuthorizedAsync } from '../lib/auth';
 import { sendBatchEmails } from '../lib/email';
-import { wrapInEmailLayout, STYLES, COLORS } from '../lib/templates/styles';
+import { wrapInEmailLayout, STYLES, COLORS, applyListStyles } from '../lib/templates/styles';
 
 function buildNewsletterEmail(
   content: string,
@@ -10,7 +10,7 @@ function buildNewsletterEmail(
 ): string {
   const innerContent = `
     <div style="${STYLES.content}">
-      ${content}
+      ${applyListStyles(content)}
     </div>
 
     <div style="${STYLES.footerWrapper}">

--- a/workers/newsletter/src/scheduled.ts
+++ b/workers/newsletter/src/scheduled.ts
@@ -3,7 +3,7 @@ import { sendBatchEmails, sendEmail } from './lib/email';
 import { recordDeliveryLogs } from './lib/delivery';
 import { processSequenceEmails } from './lib/sequence-processor';
 import { sendAbTest, sendAbTestWinner, type SendEmailFn } from './routes/ab-test-send';
-import { STYLES, COLORS, wrapInEmailLayout } from './lib/templates/styles';
+import { STYLES, COLORS, wrapInEmailLayout, applyListStyles } from './lib/templates/styles';
 
 /**
  * Extract YouTube video ID from various URL formats
@@ -99,7 +99,7 @@ function buildNewsletterEmail(
       <h1 style="${STYLES.heading(COLORS.text.primary)}">EdgeShift Newsletter</h1>
     </div>
     <div style="${STYLES.content}">
-      ${linkifyUrls(content)}
+      ${applyListStyles(linkifyUrls(content))}
     </div>
     <div style="${STYLES.footerWrapper}">
       <p style="${STYLES.footer}">


### PR DESCRIPTION
## Summary
- リストインデント縮小: 24px → 16px
- リストアイテム間隔縮小: 8px → 4px
- `applyListStyles()` で `<li>` にインラインスタイル適用

## Test plan
- [x] 全349テスト合格
- [x] Worker デプロイ済み
- [ ] 本番でメール確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)