### PR TITLE
feat(admin): make editor WYSIWYG with email format styling

### DIFF
--- a/src/components/admin/CampaignForm.tsx
+++ b/src/components/admin/CampaignForm.tsx
@@ -5,7 +5,6 @@ import { RichTextEditor } from './RichTextEditor';
 import { ListSelector } from './ListSelector';
 import { TemplateSelector } from './TemplateSelector';
 import { EmailPreviewModal } from './EmailPreviewModal';
-import { EmailPreviewPane } from './EmailPreviewPane';
 
 export interface CampaignFormRef {
   setSubject: (subject: string) => void;
@@ -205,7 +204,7 @@ export const CampaignForm = forwardRef<CampaignFormRef, CampaignFormProps>(funct
 
       {/* 2-column layout: Editor (left ~65%) + Settings (right ~35%) */}
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-6">
-        {/* Left Column: Email Content Editor with Preview */}
+        {/* Left Column: Email Content Editor (styled as email preview) */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">
@@ -221,24 +220,17 @@ export const CampaignForm = forwardRef<CampaignFormRef, CampaignFormProps>(funct
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
               </svg>
-              フルプレビュー
+              プレビュー
             </button>
           </div>
 
-          {/* Rich Text Editor */}
+          {/* Rich Text Editor styled as email preview */}
           <RichTextEditor
             value={content}
             onChange={setContent}
             placeholder="メール本文を入力..."
+            emailPreviewStyle
           />
-
-          {/* Live Email Preview Pane */}
-          <div className="mt-6">
-            <h3 className="text-sm font-medium text-[var(--color-text-secondary)] mb-3">
-              プレビュー
-            </h3>
-            <EmailPreviewPane content={content} subject={subject} />
-          </div>
         </div>
 
         {/* Right Column: Settings Panel */}

--- a/src/components/admin/RichTextEditor.tsx
+++ b/src/components/admin/RichTextEditor.tsx
@@ -9,12 +9,26 @@ interface RichTextEditorProps {
   value: string;
   onChange: (html: string) => void;
   placeholder?: string;
+  /** Render editor as email preview format (540px white box on gray background) */
+  emailPreviewStyle?: boolean;
 }
+
+// Font stack optimized for Japanese + cross-platform (from email styles)
+const EMAIL_FONT_FAMILY = [
+  '-apple-system',
+  'BlinkMacSystemFont',
+  "'Hiragino Kaku Gothic ProN'",
+  "'Hiragino Sans'",
+  'Meiryo',
+  "'Segoe UI'",
+  'sans-serif',
+].join(', ');
 
 export function RichTextEditor({
   value,
   onChange,
   placeholder = 'Start typing...',
+  emailPreviewStyle = false,
 }: RichTextEditorProps) {
   const editor = useEditor({
     extensions: [
@@ -25,7 +39,7 @@ export function RichTextEditor({
       Link.configure({
         openOnClick: false,
         HTMLAttributes: {
-          class: 'text-blue-600 underline',
+          class: emailPreviewStyle ? 'email-editor-link' : 'text-blue-600 underline',
         },
       }),
       Placeholder.configure({
@@ -38,8 +52,9 @@ export function RichTextEditor({
     },
     editorProps: {
       attributes: {
-        class:
-          'prose prose-sm max-w-none min-h-[300px] p-4 focus:outline-none',
+        class: emailPreviewStyle
+          ? 'email-editor-content min-h-[300px] focus:outline-none'
+          : 'prose prose-sm max-w-none min-h-[300px] p-4 focus:outline-none',
       },
     },
   });
@@ -50,6 +65,135 @@ export function RichTextEditor({
       editor.commands.setContent(value);
     }
   }, [value, editor]);
+
+  if (emailPreviewStyle) {
+    return (
+      <div className="rounded-lg overflow-hidden">
+        {/* MenuBar at top */}
+        <div className="bg-white border border-gray-300 rounded-t-lg">
+          <MenuBar editor={editor} />
+        </div>
+
+        {/* Email preview styled editor */}
+        <div
+          className="rounded-b-lg"
+          style={{
+            backgroundColor: '#f5f5f5',
+            padding: '24px 16px',
+          }}
+        >
+          {/* White content box - matches email format */}
+          <div
+            style={{
+              backgroundColor: '#ffffff',
+              maxWidth: '540px',
+              margin: '0 auto',
+              padding: '24px',
+              borderRadius: '8px',
+              fontFamily: EMAIL_FONT_FAMILY,
+              fontSize: '16px',
+              lineHeight: '1.5',
+              letterSpacing: '0.02em',
+              color: '#1e1e1e',
+            }}
+          >
+            <EditorContent editor={editor} />
+          </div>
+        </div>
+
+        {/* Scoped styles for email editor content */}
+        <style>{`
+          .email-editor-content {
+            font-family: ${EMAIL_FONT_FAMILY};
+            font-size: 16px;
+            line-height: 1.5;
+            letter-spacing: 0.02em;
+            color: #1e1e1e;
+          }
+          .email-editor-content p {
+            margin: 0 0 12px 0;
+          }
+          .email-editor-content p:last-child {
+            margin-bottom: 0;
+          }
+          .email-editor-content p.is-editor-empty:first-child::before {
+            color: #adb5bd;
+            content: attr(data-placeholder);
+            float: left;
+            height: 0;
+            pointer-events: none;
+          }
+          .email-editor-content h1,
+          .email-editor-content h2,
+          .email-editor-content h3 {
+            margin: 0 0 12px 0;
+            line-height: 1.4;
+            letter-spacing: 0.01em;
+            font-weight: 600;
+          }
+          .email-editor-content h1 {
+            font-size: 24px;
+          }
+          .email-editor-content h2 {
+            font-size: 20px;
+          }
+          .email-editor-content h3 {
+            font-size: 18px;
+          }
+          .email-editor-content ul,
+          .email-editor-content ol {
+            margin: 0 0 12px 0;
+            padding-left: 16px;
+          }
+          .email-editor-content li {
+            margin-bottom: 4px;
+          }
+          .email-editor-link {
+            color: #7c3aed;
+            text-decoration: none;
+          }
+          .email-editor-link:hover {
+            text-decoration: underline;
+          }
+          .email-editor-content blockquote {
+            margin: 0 0 12px 0;
+            padding-left: 16px;
+            border-left: 3px solid #e5e5e5;
+            color: #525252;
+          }
+          .email-editor-content hr {
+            border: none;
+            border-top: 1px solid #e5e5e5;
+            margin: 24px 0;
+          }
+          .email-editor-content strong {
+            font-weight: 600;
+          }
+          .email-editor-content em {
+            font-style: italic;
+          }
+          .email-editor-content code {
+            background-color: #f5f5f5;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 14px;
+          }
+          .email-editor-content pre {
+            background-color: #f5f5f5;
+            padding: 12px;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin: 0 0 12px 0;
+          }
+          .email-editor-content pre code {
+            background-color: transparent;
+            padding: 0;
+          }
+        `}</style>
+      </div>
+    );
+  }
 
   return (
     <div className="border border-gray-300 rounded-lg overflow-hidden bg-white">


### PR DESCRIPTION
## Summary
- エディタ自体がメールプレビューを兼ねるよう変更（540px幅の白ボックス + グレー背景）
- 常時表示のプレビューパネルを削除（編集中に実際のメール形式が確認可能）
- モーダルプレビューボタンは維持（フルスクリーン確認用）

## Changes
- `RichTextEditor.tsx`: `emailPreviewStyle` prop 追加でメール形式スタイル適用
- `CampaignForm.tsx`: 常時プレビューパネル削除、エディタにスタイル適用

## Test plan
- [ ] 管理画面のキャンペーン作成ページでエディタが540px幅で表示される
- [ ] グレー背景 + 白ボックスのスタイルが適用されている
- [ ] リスト・見出し・リンクが実際のメールと同じスタイルで表示される
- [ ] 「プレビュー」ボタンでモーダルプレビューが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)