### PR TITLE
fix: image upload response structure and YouTube anchor conversion

### DIFF
--- a/workers/newsletter/src/routes/images.ts
+++ b/workers/newsletter/src/routes/images.ts
@@ -35,7 +35,7 @@ function generateFilename(mimeType: string): string {
  * Upload an image to R2 bucket
  *
  * Request: multipart/form-data with 'file' field
- * Response: { success: true, data: { url: string } }
+ * Response: { url: string, filename: string }
  */
 export async function handleImageUpload(
   request: Request,
@@ -113,10 +113,7 @@ export async function handleImageUpload(
     const publicUrl = `${baseUrl}/${filename}`;
 
     return new Response(
-      JSON.stringify({
-        success: true,
-        data: { url: publicUrl, filename },
-      }),
+      JSON.stringify({ url: publicUrl, filename }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     );
   } catch (error) {


### PR DESCRIPTION
## 問題

1. **画像アップロード**: `src="undefined"` になる - Worker が `{ success: true, data: { url } }` を返し、admin-api が再度ラップして `result.data.data.url` になっていた
2. **YouTube**: `[YouTube Video]` のまま - エディタが `<a href="...">` 形式で挿入するが、`convertYoutubeUrls` がこの形式を無視していた

## 修正

- `images.ts`: `{ url, filename }` を直接返すように変更
- `scheduled.ts`: `convertYoutubeAnchors()` を追加して `<a href="YOUTUBE_URL">...</a>` 形式も変換

## Test plan
- [ ] 画像アップロードで正しいURLが挿入される
- [ ] YouTube リンクがサムネイルに変換されてメール配信される

🤖 Generated with [Claude Code](https://claude.com/claude-code)