### PR TITLE
fix: add /api/images route and display: block for images

### DIFF
--- a/src/components/admin/MenuBar.tsx
+++ b/src/components/admin/MenuBar.tsx
@@ -85,7 +85,7 @@ export function MenuBar({ editor }: MenuBarProps) {
       }
 
       // Insert image into editor
-      const imgHtml = `<img src="${result.data.url}" alt="Image" style="max-width: 100%; height: auto;" />`;
+      const imgHtml = `<img src="${result.data.url}" alt="Image" style="display: block; max-width: 100%; height: auto;" />`;
       editor?.chain().focus().insertContent(imgHtml).run();
     } catch (error) {
       console.error('Image upload error:', {
@@ -141,7 +141,7 @@ export function MenuBar({ editor }: MenuBarProps) {
       return;
     }
 
-    const imgHtml = `<img src="${url}" alt="Image" style="max-width: 100%; height: auto;" />`;
+    const imgHtml = `<img src="${url}" alt="Image" style="display: block; max-width: 100%; height: auto;" />`;
     editor?.chain().focus().insertContent(imgHtml).run();
   };
 

--- a/workers/newsletter/src/__tests__/content-processor.test.ts
+++ b/workers/newsletter/src/__tests__/content-processor.test.ts
@@ -350,7 +350,7 @@ describe('Content Processor', () => {
     it('should add responsive styles to img tags without style attribute', () => {
       const html = '<p>Here is an image:</p><img src="https://example.com/image.jpg">';
       const result = linkifyUrls(html);
-      expect(result).toContain('style="max-width: 100%; height: auto;"');
+      expect(result).toContain('style="display: block; max-width: 100%; height: auto;"');
     });
 
     it('should append responsive styles to img tags with existing style', () => {
@@ -372,7 +372,7 @@ describe('Content Processor', () => {
     it('should add responsive styles to img tag without style', () => {
       const html = '<img src="https://example.com/image.jpg">';
       const result = ensureImageMaxWidth(html);
-      expect(result).toBe('<img src="https://example.com/image.jpg" style="max-width: 100%; height: auto;">');
+      expect(result).toBe('<img src="https://example.com/image.jpg" style="display: block; max-width: 100%; height: auto;">');
     });
 
     it('should append responsive styles to existing style', () => {
@@ -405,7 +405,7 @@ describe('Content Processor', () => {
     it('should handle multiple img tags', () => {
       const html = '<img src="a.jpg"><p>text</p><img src="b.jpg" style="border: 1px solid;">';
       const result = ensureImageMaxWidth(html);
-      expect(result).toContain('<img src="a.jpg" style="max-width: 100%; height: auto;">');
+      expect(result).toContain('<img src="a.jpg" style="display: block; max-width: 100%; height: auto;">');
       expect(result).toContain('border: 1px solid;');
       expect(result).toContain('max-width: 100%;');
     });
@@ -415,7 +415,7 @@ describe('Content Processor', () => {
       const result = ensureImageMaxWidth(html);
       expect(result).toContain('src="test.jpg"');
       expect(result).toContain('alt="Test image"');
-      expect(result).toContain('style="max-width: 100%; height: auto;"');
+      expect(result).toContain('style="display: block; max-width: 100%; height: auto;"');
     });
 
     it('should handle self-closing img tags', () => {

--- a/workers/newsletter/src/lib/content-processor.ts
+++ b/workers/newsletter/src/lib/content-processor.ts
@@ -99,7 +99,7 @@ export function convertYoutubeUrls(text: string): string {
  * - Skips if max-width is already specified in style
  */
 export function ensureImageMaxWidth(html: string): string {
-  const responsiveStyles = 'max-width: 100%; height: auto;';
+  const responsiveStyles = 'display: block; max-width: 100%; height: auto;';
 
   return html.replace(/<img\s+([^>]*)>/gi, (match, attributes: string) => {
     // Check if style attribute exists

--- a/workers/newsletter/wrangler.toml
+++ b/workers/newsletter/wrangler.toml
@@ -89,6 +89,10 @@ pattern = "edgeshift.tech/api/brand-settings"
 zone_name = "edgeshift.tech"
 
 [[routes]]
+pattern = "edgeshift.tech/api/images"
+zone_name = "edgeshift.tech"
+
+[[routes]]
 pattern = "edgeshift.tech/api/images/*"
 zone_name = "edgeshift.tech"
 


### PR DESCRIPTION
## Summary
- wrangler.toml に `/api/images` 正確なルートを追加（Library API 404 修正）
- 画像に `display: block` を追加（はみ出し修正）

## Changes
- `wrangler.toml`: `/api/images` パターン追加
- `content-processor.ts`: `ensureImageMaxWidth` に `display: block` 追加
- `MenuBar.tsx`: 画像挿入時に `display: block` 追加
- テスト更新

## Test plan
- [ ] Library ボタンで画像一覧が表示される
- [ ] プレビューで画像がはみ出さない
- [ ] メール送信後も画像がはみ出さない

🤖 Generated with [Claude Code](https://claude.com/claude-code)