### PR TITLE
fix(styles): reset paragraph margin inside list items

### DIFF
--- a/workers/newsletter/src/lib/templates/styles.ts
+++ b/workers/newsletter/src/lib/templates/styles.ts
@@ -163,7 +163,7 @@ export function applyListStyles(html: string): string {
     .replace(/<li(?![^>]*style=)/gi, `<li style="${STYLES.listItem}"`)
     // Reset margin on <p> tags inside <li> (TipTap wraps list content in <p>)
     // Email clients apply default margin to <p> which causes extra spacing
-    .replace(/<li([^>]*)><p(?![^>]*style=)/gi, '<li$1><p style="margin:0"');
+    .replace(/(<li[^>]*>)(\s*)(<p)(?![^>]*style=)/gi, '$1$2$3 style="margin:0"');
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix excessive spacing in email list items caused by TipTap wrapping list content in `<p>` tags
- Email clients like Gmail apply default 16px margin to `<p>` elements inside `<li>`
- Add regex to `applyListStyles()` that sets `margin:0` on `<p>` tags inside `<li>` elements

## Test plan

- [ ] Send a test email containing bullet lists
- [ ] Verify list items display without excessive vertical spacing in Gmail
- [ ] Verify list items display correctly in other email clients (Apple Mail, Outlook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)