### PR TITLE
fix: detect Japanese headers in CSV import preview

### DIFF
--- a/src/components/admin/ImportModal.tsx
+++ b/src/components/admin/ImportModal.tsx
@@ -77,9 +77,13 @@ export function ImportModal({ isOpen, onClose, onSuccess }: Props) {
         return;
       }
 
-      // Detect header
+      // Detect header (supports English and Japanese)
       const header = lines[0].toLowerCase();
-      const hasHeader = header.includes('email') || header.includes('name');
+      const hasHeader =
+        header.includes('email') ||
+        header.includes('name') ||
+        header.includes('eメール') ||
+        header.includes('メールアドレス');
       const dataStart = hasHeader ? 1 : 0;
 
       const rows: PreviewRow[] = [];


### PR DESCRIPTION
## Summary
- Add detection for Japanese email headers in CSV import preview
- Fixes header row appearing as data when CSV has Japanese headers

## Problem
When importing a CSV with Japanese headers like `Eメール`, the frontend preview parser didn't recognize it as a header row, causing:
- Header row displayed as first data row in preview
- Incorrect row count (917 instead of 916)

## Solution
Extended header detection to include:
- `eメール` (Japanese for "Email")
- `メールアドレス` (Japanese for "Email address")

## Test plan
- [ ] Import CSV with `Eメール` header - header should not appear in preview
- [ ] Import CSV with `email` header - still works
- [ ] Row count should be accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)