### PR TITLE
fix: use isAuthorizedAsync for import/export endpoints

### DIFF
--- a/workers/newsletter/src/routes/import-export.ts
+++ b/workers/newsletter/src/routes/import-export.ts
@@ -7,7 +7,7 @@
 
 import type { Env, ImportResult, Subscriber, ExportOptions } from '../types';
 import { splitName } from '../lib/resend-marketing';
-import { isAuthorized } from '../lib/auth';
+import { isAuthorizedAsync } from '../lib/auth';
 
 // ============================================================================
 // CSV Parsing Utilities
@@ -168,8 +168,8 @@ export async function handleImport(
   request: Request,
   env: Env
 ): Promise<Response> {
-  // Check authorization (using sync version for API key auth)
-  if (!isAuthorized(request, env)) {
+  // Check authorization (supports API key, CF Access, and session)
+  if (!(await isAuthorizedAsync(request, env))) {
     return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },
@@ -347,8 +347,8 @@ export async function handleExport(
   request: Request,
   env: Env
 ): Promise<Response> {
-  // Check authorization
-  if (!isAuthorized(request, env)) {
+  // Check authorization (supports API key, CF Access, and session)
+  if (!(await isAuthorizedAsync(request, env))) {
     return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Fix 401 Unauthorized error when using import/export via admin UI

## Problem
Import and export endpoints used `isAuthorized()` which only supports API key authentication. Admin UI users authenticate via Cloudflare Access (JWT) which wasn't being checked.

## Solution
Changed to `isAuthorizedAsync()` which supports:
- API key (`Authorization: Bearer`)
- CF Access JWT (`CF_Authorization` cookie)
- Session cookie (Magic Link + TOTP)

## Already deployed
Worker has been deployed with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)