### PR TITLE
fix(resend): use correct API endpoint for adding contacts to segments

### DIFF
--- a/workers/newsletter/src/__tests__/resend-marketing.test.ts
+++ b/workers/newsletter/src/__tests__/resend-marketing.test.ts
@@ -347,13 +347,12 @@ describe('Resend Marketing API Service', () => {
       expect(result.errors).toHaveLength(0);
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
-      // Verify correct API endpoint: POST /contacts/segments/add with body
+      // Verify correct API endpoint: POST /contacts/{contact_id}/segments/{segment_id}
       expect(mockFetch).toHaveBeenNthCalledWith(
         1,
-        'https://api.resend.com/contacts/segments/add',
+        'https://api.resend.com/contacts/contact-1/segments/segment-123',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ contactId: 'contact-1', segmentId: 'segment-123' }),
         })
       );
     });

--- a/workers/newsletter/src/lib/resend-marketing.ts
+++ b/workers/newsletter/src/lib/resend-marketing.ts
@@ -340,8 +340,8 @@ interface AddContactToSegmentResponse {
  * Add contacts to a segment in batch.
  * Contacts must be specified by contact ID (not email).
  *
- * Resend API: POST /contacts/segments/add
- * Body: { contactId, segmentId }
+ * Resend API: POST /contacts/{contact_id}/segments/{segment_id}
+ * (Path parameters, no request body)
  */
 export async function addContactsToSegment(
   config: ResendMarketingConfig,
@@ -361,18 +361,15 @@ export async function addContactsToSegment(
     }
 
     try {
+      // Correct endpoint: /contacts/{contact_id}/segments/{segment_id}
       const response = await fetchWithRetry(
-        `${RESEND_API_BASE}/contacts/segments/add`,
+        `${RESEND_API_BASE}/contacts/${contactId}/segments/${segmentId}`,
         {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${config.apiKey}`,
-            'Content-Type': 'application/json',
           },
-          body: JSON.stringify({
-            contactId,
-            segmentId,
-          }),
+          // No body - contact_id and segment_id are path parameters
         }
       );
 


### PR DESCRIPTION
## Summary
- Fix HTTP 405 error when sending campaigns to contact lists
- Changed Resend API endpoint from `POST /contacts/segments/add` (body params) to `POST /contacts/{contact_id}/segments/{segment_id}` (path params)
- Updated corresponding test

## Root Cause
The Resend REST API uses path parameters for the "add contact to segment" endpoint, not a request body. The SDK abstracts this, but direct REST calls require the correct URL format.

## Test plan
- [x] Unit tests pass (`npm test -- src/__tests__/resend-marketing.test.ts`)
- [ ] Manual test: Send campaign to "test" contact list in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)