### PR TITLE
fix(editor): match email content width with box-sizing

### DIFF
--- a/src/components/admin/RichTextEditor.tsx
+++ b/src/components/admin/RichTextEditor.tsx
@@ -93,6 +93,7 @@ export function RichTextEditor({
           {/* White content box - matches email format */}
           <div
             style={{
+              boxSizing: 'content-box', // Match email template (not Tailwind's border-box)
               backgroundColor: '#ffffff',
               maxWidth: '540px',
               margin: '0 auto',


### PR DESCRIPTION
## Summary

- Fix editor content width to match actual email rendering
- Tailwind applies `border-box` globally, but email templates use `content-box`
- This caused the editor to show 48px narrower content than actual emails

## Changes

- Add `boxSizing: 'content-box'` to RichTextEditor white content box
- Now editor and email preview show identical line breaks

## Test plan

- [ ] Open campaign edit page
- [ ] Type a long line of text in the editor
- [ ] Click preview button
- [ ] Verify line breaks occur at the same position in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)