### PR TITLE
fix: Resend subdomain migration (mail → send)

### DIFF
--- a/workers/contact-form/src/index.ts
+++ b/workers/contact-form/src/index.ts
@@ -1,6 +1,7 @@
 interface Env {
   RESEND_API_KEY: string;
   RECIPIENT_EMAIL: string;
+  SENDER_EMAIL: string;
   ALLOWED_ORIGIN: string;
 }
 
@@ -160,7 +161,7 @@ async function sendEmail(env: Env, data: ContactFormData): Promise<void> {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: 'EdgeShift Contact <noreply@mail.edgeshift.tech>',
+      from: `EdgeShift Contact <${env.SENDER_EMAIL}>`,
       to: env.RECIPIENT_EMAIL,
       reply_to: data.email,
       subject,

--- a/workers/contact-form/wrangler.toml
+++ b/workers/contact-form/wrangler.toml
@@ -2,11 +2,12 @@ name = "edgeshift-contact-form"
 main = "src/index.ts"
 compatibility_date = "2024-12-01"
 
-[vars]
-RECIPIENT_EMAIL = "contact@edgeshift.tech"
-ALLOWED_ORIGIN = "https://edgeshift.tech"
-
 # Production route
 routes = [
   { pattern = "edgeshift.tech/api/contact", zone_name = "edgeshift.tech" }
 ]
+
+[vars]
+RECIPIENT_EMAIL = "contact@edgeshift.tech"
+SENDER_EMAIL = "noreply@send.edgeshift.tech"
+ALLOWED_ORIGIN = "https://edgeshift.tech"

--- a/workers/newsletter/wrangler.toml
+++ b/workers/newsletter/wrangler.toml
@@ -98,7 +98,7 @@ zone_name = "edgeshift.tech"
 
 [vars]
 ALLOWED_ORIGIN = "https://edgeshift.tech"
-SENDER_EMAIL = "newsletter@mail.edgeshift.tech"
+SENDER_EMAIL = "newsletter@send.edgeshift.tech"
 SENDER_NAME = "EdgeShift Newsletter"
 SITE_URL = "https://edgeshift.tech"
 IMAGES_PUBLIC_URL = "https://images.edgeshift.tech"


### PR DESCRIPTION
## Summary

- メール送信サブドメインを `mail.edgeshift.tech` → `send.edgeshift.tech` に移行
- AI テストによるバウンス率 27.5% でドメインレピュテーションが低下していたため、新サブドメインで再スタート
- ハードコードされたメールアドレスを環境変数に変更（将来の柔軟性確保）

## Changes

- **Newsletter Worker**: `SENDER_EMAIL` を `newsletter@send.edgeshift.tech` に更新
- **Contact Form Worker**: 
  - `SENDER_EMAIL` 環境変数を追加
  - ハードコードされたアドレスを `env.SENDER_EMAIL` に変更
  - `wrangler.toml` の `routes` を `[vars]` の前に移動（TOML解釈の問題を修正）

## Test Plan

- [x] Newsletter Worker デプロイ済み・テスト済み
- [x] Contact Form Worker デプロイ済み・テスト済み
- [x] Gmail / Mac Mail でメール受信確認
- [x] Contact Form が迷惑メールではなく受信箱に届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)