### PR TITLE
fix: convert Unix timestamp to milliseconds in archive date formatting

### DIFF
--- a/src/pages/newsletter/archive/[slug].astro
+++ b/src/pages/newsletter/archive/[slug].astro
@@ -61,9 +61,10 @@ if (notFound || !article) {
   return new Response('Article not found', { status: 404 });
 }
 
-// Format date
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
+// Format date (sent_at is Unix timestamp in seconds)
+function formatDate(timestamp: string | number): string {
+  const ts = typeof timestamp === 'string' ? parseInt(timestamp, 10) : timestamp;
+  const date = new Date(ts * 1000); // Convert seconds to milliseconds
   return date.toLocaleDateString('ja-JP', {
     year: 'numeric',
     month: 'long',

--- a/src/pages/newsletter/archive/index.astro
+++ b/src/pages/newsletter/archive/index.astro
@@ -59,9 +59,10 @@ function extractExcerpt(html: string): string {
   return text.length > 200 ? text.substring(0, 200) + '...' : text;
 }
 
-// Format date to Japanese format
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
+// Format date to Japanese format (sent_at is Unix timestamp in seconds)
+function formatDate(timestamp: string | number): string {
+  const ts = typeof timestamp === 'string' ? parseInt(timestamp, 10) : timestamp;
+  const date = new Date(ts * 1000); // Convert seconds to milliseconds
   return date.toLocaleDateString('ja-JP', {
     year: 'numeric',
     month: 'long',

--- a/src/pages/newsletter/feed.xml.ts
+++ b/src/pages/newsletter/feed.xml.ts
@@ -41,9 +41,11 @@ function escapeXml(unsafe: string): string {
 /**
  * Format date to RFC 822 (required by RSS 2.0)
  * Example: "Wed, 02 Oct 2002 13:00:00 GMT"
+ * Note: sent_at is Unix timestamp in seconds
  */
-function toRFC822(dateStr: string): string {
-  const date = new Date(dateStr);
+function toRFC822(timestamp: string | number): string {
+  const ts = typeof timestamp === 'string' ? parseInt(timestamp, 10) : timestamp;
+  const date = new Date(ts * 1000); // Convert seconds to milliseconds
   return date.toUTCString();
 }
 


### PR DESCRIPTION
## Summary
- Fix archive page showing '1970年1月21日' instead of correct dates
- `sent_at` is Unix timestamp in seconds, but `new Date()` expects milliseconds
- Multiply by 1000 to convert correctly

## Files Changed
- `src/pages/newsletter/archive/index.astro`
- `src/pages/newsletter/archive/[slug].astro`
- `src/pages/newsletter/feed.xml.ts`

## Test Plan
- [x] Verified on preview URL: https://963a4c5a.edgeshift.pages.dev/newsletter/archive
- [x] Dates now display correctly (e.g., 2026年1月22日)

🤖 Generated with [Claude Code](https://claude.com/claude-code)