### PR TITLE
fix: sequence delete FK constraint and broadcast sender import

### DIFF
--- a/workers/newsletter/src/routes/sequences.ts
+++ b/workers/newsletter/src/routes/sequences.ts
@@ -244,6 +244,11 @@ export async function deleteSequence(
       return errorResponse('Sequence not found', 404);
     }
 
+    // Clear sequence references in delivery_logs (no CASCADE on these FKs)
+    await env.DB.prepare(
+      'UPDATE delivery_logs SET sequence_id = NULL, sequence_step_id = NULL WHERE sequence_id = ?'
+    ).bind(id).run();
+
     // Delete sequence (CASCADE will delete steps and enrollments)
     await env.DB.prepare('DELETE FROM sequences WHERE id = ?').bind(id).run();
 


### PR DESCRIPTION
## Summary
- Fix sequence delete returning 500 Internal Server Error
- Fix build error from missing `addContactToDefaultSegment` function

## Root Cause Analysis

### Sequence Delete Error
- `delivery_logs` table has FK to `sequences` without `ON DELETE CASCADE`
- Deleting a sequence with related delivery_logs fails on FK constraint
- Fix: Clear `sequence_id` and `sequence_step_id` in delivery_logs before delete

### Build Error
- `addContactToDefaultSegment` was removed/renamed to `addContactsToSegment`
- Import in `broadcast-sender.ts` was not updated
- Fix: Update import and usage to use array-based function

## Files Changed
- `workers/newsletter/src/routes/sequences.ts` - Clear FK references before delete
- `workers/newsletter/src/lib/broadcast-sender.ts` - Update import and usage

## Test Plan
- [x] Deployed and tested sequence delete - now works
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)