### PR TITLE
送信元情報を個人ブランディングに更新

### DIFF
--- a/workers/newsletter/wrangler.toml
+++ b/workers/newsletter/wrangler.toml
@@ -107,8 +107,8 @@ zone_name = "edgeshift.tech"
 
 [vars]
 ALLOWED_ORIGIN = "https://edgeshift.tech"
-SENDER_EMAIL = "newsletter@send.edgeshift.tech"
-SENDER_NAME = "EdgeShift Newsletter"
+SENDER_EMAIL = "info@edgeshift.tech"
+SENDER_NAME = "井村尚弥@EdgeShift"
 SITE_URL = "https://edgeshift.tech"
 IMAGES_PUBLIC_URL = "https://images.edgeshift.tech"
 # ADMIN_EMAIL = "admin@edgeshift.tech"  # Optional: set for milestone achievement notifications


### PR DESCRIPTION
## Summary

送信元情報を個人ブランディング仕様に変更しました。

### Changes

- **送信元名**: `EdgeShift Newsletter` → `井村尚弥@EdgeShift`
- **送信元メールアドレス**: `newsletter@send.edgeshift.tech` → `info@edgeshift.tech`

### Impact

この変更により、以下のすべての送信メールに適用されます：
- キャンペーン配信
- シーケンスステップメール
- 購読確認メール
- その他の自動送信メール

### Deployment

wrangler.toml の変更後、既に本番環境にデプロイ済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)