### PR TITLE
fix: change sender name to avoid iOS Mail display issue

### DIFF
--- a/workers/newsletter/wrangler.toml
+++ b/workers/newsletter/wrangler.toml
@@ -107,8 +107,8 @@ zone_name = "edgeshift.tech"
 
 [vars]
 ALLOWED_ORIGIN = "https://edgeshift.tech"
-SENDER_EMAIL = "info@edgeshift.tech"
-SENDER_NAME = "井村尚弥@EdgeShift"
+SENDER_EMAIL = "info@send.edgeshift.tech"
+SENDER_NAME = "井村尚弥"
 SITE_URL = "https://edgeshift.tech"
 IMAGES_PUBLIC_URL = "https://images.edgeshift.tech"
 # ADMIN_EMAIL = "admin@edgeshift.tech"  # Optional: set for milestone achievement notifications


### PR DESCRIPTION
## 概要

iOS Mailで送信者名が表示されない問題の暫定対応 + SENDER_EMAIL修正。

## 問題1: iOS Mail表示問題

送信者名「井村尚弥@EdgeShift」がiOS Mailで表示されない。
- iOS Mail: ❌ 表示されない（空白）
- Gmail/Yahoo: ✅ 正常に表示

### 根本原因

送信者名に日本語（非ASCII）+ @記号（特殊文字）の組み合わせが含まれており、RFC 2047 MIME encoded-wordが必要だが、現在のResend APIは自動的にquoted-stringを追加するのみでMIMEエンコーディングを行わない。

### 検証結果

| 送信者名 | iOS Mail表示 |
|---------|------------|
| EdgeShift Newsletter | ✅ 表示される |
| 井村尚弥 | ✅ 表示される（暫定対応） |
| 井村尚弥@EdgeShift | ❌ 表示されない |

## 問題2: SENDER_EMAIL設定ミス

PR #138でマージされた設定が間違っている：
- `info@edgeshift.tech` → ❌ ルートドメイン未承認（HTTP 403エラー）
- `info@send.edgeshift.tech` → ✅ サブドメイン承認済み

## 変更内容

```diff
- SENDER_EMAIL = "info@edgeshift.tech"
- SENDER_NAME = "井村尚弥@EdgeShift"
+ SENDER_EMAIL = "info@send.edgeshift.tech"
+ SENDER_NAME = "井村尚弥"
```

### 修正内容

1. **SENDER_NAME**: `井村尚弥@EdgeShift` → `井村尚弥`（iOS Mail対応）
2. **SENDER_EMAIL**: `info@edgeshift.tech` → `info@send.edgeshift.tech`（403エラー修正）

## 恒久対応

Issue #139でRFC 2047対応を実装予定。
実装後は任意の非ASCII文字・特殊文字を送信者名に使用可能になります。

## テスト

- [x] Workerデプロイ完了
- [x] コンフリクト解決（mainブランチとrebase済み）
- [ ] iOS Mailでテストメール確認（ユーザー確認待ち）

Related: #139