### PR TITLE
fix: correct isUnsubscribeUrl pattern to match triple braces

### DIFF
--- a/workers/newsletter/src/routes/redirect.ts
+++ b/workers/newsletter/src/routes/redirect.ts
@@ -8,13 +8,13 @@ import { updateContactUnsubscribe, type ResendMarketingConfig } from '../lib/res
  * Patterns:
  * - unsubscribe.resend.com (Resend's unsubscribe domain)
  * - /api/newsletter/unsubscribe (our unsubscribe endpoint)
- * - {{RESEND_UNSUBSCRIBE_URL}} (placeholder - shouldn't happen with Task 1 fix, but safeguard)
+ * - RESEND_UNSUBSCRIBE_URL (placeholder - matches both {{...}} and {{{...}}} formats)
  */
 function isUnsubscribeUrl(url: string): boolean {
   return (
     url.includes('unsubscribe.resend.com') ||
     url.includes('/api/newsletter/unsubscribe') ||
-    url.includes('{{RESEND_UNSUBSCRIBE_URL}}')
+    url.includes('RESEND_UNSUBSCRIBE_URL')
   );
 }
 


### PR DESCRIPTION
## Summary

- Fix `isUnsubscribeUrl` pattern mismatch: was checking `{{RESEND_UNSUBSCRIBE_URL}}` (double braces) but actual placeholder is `{{{RESEND_UNSUBSCRIBE_URL}}}` (triple braces - Mustache unescaped syntax)
- Changed to check for `RESEND_UNSUBSCRIBE_URL` without braces to match both formats

## Root Cause

| Location | Pattern | Match? |
|----------|---------|--------|
| Template | `{{{RESEND_UNSUBSCRIBE_URL}}}` | - |
| url-shortener.ts | `RESEND_UNSUBSCRIBE_URL` | ✅ |
| redirect.ts (before) | `{{RESEND_UNSUBSCRIBE_URL}}` | ❌ |
| redirect.ts (after) | `RESEND_UNSUBSCRIBE_URL` | ✅ |

## Affected User

- `kabi0511w1@gmail.com` - clicked shortened unsubscribe link but wasn't auto-unsubscribed
- Manually unsubscribed in D1

## Test plan

- [x] Worker deployed
- [x] Affected user manually unsubscribed

🤖 Generated with [Claude Code](https://claude.ai/code)