### PR TITLE
fix: move useEffect hooks before early returns

### DIFF
--- a/src/components/shop/ShopProductDetail.tsx
+++ b/src/components/shop/ShopProductDetail.tsx
@@ -70,6 +70,25 @@ export default function ShopProductDetail() {
     fetchProduct();
   }, []);
 
+  // Reset checkout loading on bfcache restore (browser back from Stripe)
+  useEffect(() => {
+    const handler = (e: PageTransitionEvent) => {
+      if (e.persisted) setCheckoutLoading(false);
+    };
+    window.addEventListener('pageshow', handler);
+    return () => window.removeEventListener('pageshow', handler);
+  }, []);
+
+  // Close modal on Escape key
+  useEffect(() => {
+    if (!showCheckoutModal) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !checkoutLoading) setShowCheckoutModal(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [showCheckoutModal, checkoutLoading]);
+
   // Sanitize long_description HTML with DOMPurify (defense-in-depth)
   const sanitizedDescription = useMemo(() => {
     if (!product?.long_description) return '';
@@ -131,25 +150,6 @@ export default function ShopProductDetail() {
   }
 
   if (!product) return null;
-
-  // Reset checkout loading on bfcache restore (browser back from Stripe)
-  useEffect(() => {
-    const handler = (e: PageTransitionEvent) => {
-      if (e.persisted) setCheckoutLoading(false);
-    };
-    window.addEventListener('pageshow', handler);
-    return () => window.removeEventListener('pageshow', handler);
-  }, []);
-
-  // Close modal on Escape key
-  useEffect(() => {
-    if (!showCheckoutModal) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !checkoutLoading) setShowCheckoutModal(false);
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [showCheckoutModal, checkoutLoading]);
 
   const handleCheckout = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Fix React error #310 (hooks called in different order between renders)
- The bfcache and Escape key `useEffect` hooks were placed after `if (!product) return null;` early return
- Moved them before all early returns, alongside other hooks

## Root cause
React Rules of Hooks require all hooks to be called in the same order on every render. When `product` is null, the early return skipped the hooks, causing a mismatch on the next render when product was loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)