### PR TITLE
fix: add mobile responsive layout to My Page

### DIFF
--- a/src/layouts/MyPageLayout.astro
+++ b/src/layouts/MyPageLayout.astro
@@ -32,9 +32,43 @@ function isActive(href: string): boolean {
     <title>{fullTitle}</title>
   </head>
   <body class="min-h-screen bg-gray-50">
+    <!-- Mobile header -->
+    <header class="md:hidden sticky top-0 z-30 bg-white border-b border-gray-200">
+      <div class="flex items-center justify-between px-4 py-3">
+        <a href="/my" class="text-lg font-bold text-blue-600">EdgeShift</a>
+        <button id="mobile-menu-btn" class="p-2 text-gray-600 hover:text-gray-900" aria-label="メニュー">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <nav id="mobile-menu" class="hidden border-t border-gray-100 bg-white">
+        <ul class="py-2">
+          {navItems.map((item) => (
+            <li>
+              <a
+                href={item.href}
+                class:list={[
+                  'block px-6 py-2.5 text-sm',
+                  isActive(item.href)
+                    ? 'bg-blue-50 text-blue-700 font-medium'
+                    : 'text-gray-600',
+                ]}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+          <li class="border-t border-gray-100 mt-2 pt-2">
+            <a href="/shop" class="block px-6 py-2.5 text-sm text-gray-500">ショップ</a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+
     <div class="flex min-h-screen">
-      <!-- Sidebar -->
-      <aside class="w-64 bg-white border-r border-gray-200 flex-shrink-0 flex flex-col">
+      <!-- Sidebar (desktop only) -->
+      <aside class="hidden md:flex w-64 bg-white border-r border-gray-200 flex-shrink-0 flex-col">
         <div class="p-4 border-b border-gray-200">
           <a href="/my" class="text-xl font-bold text-blue-600">EdgeShift</a>
           <p class="text-xs text-gray-400 mt-1">マイページ</p>
@@ -94,9 +128,17 @@ function isActive(href: string): boolean {
       </aside>
 
       <!-- Main content -->
-      <main class="flex-1 p-8">
+      <main class="flex-1 p-4 md:p-8">
         <slot />
       </main>
     </div>
+
+    <script>
+      const btn = document.getElementById('mobile-menu-btn');
+      const menu = document.getElementById('mobile-menu');
+      if (btn && menu) {
+        btn.addEventListener('click', () => menu.classList.toggle('hidden'));
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Hide sidebar on mobile (< md breakpoint), show sticky header with hamburger menu
- Reduce main content padding on mobile (p-4 vs p-8)
- Desktop layout unchanged (sidebar remains)

## Test plan
- [x] Mobile (375px): hamburger menu opens/closes, all nav links visible
- [x] Desktop (1280px): sidebar displays normally
- [x] Deployed and verified on production

🤖 Generated with [Claude Code](https://claude.ai/code)