### PR TITLE
feat: add Elementor manual course registration LP

### DIFF
--- a/src/components/auth/SessionAuthProvider.tsx
+++ b/src/components/auth/SessionAuthProvider.tsx
@@ -22,7 +22,7 @@ export function useSessionAuth() {
 interface SessionAuthProviderProps {
   children: ReactNode;
   redirectTo?: string;
-  requiredRole?: ('owner' | 'admin' | 'subscriber')[];
+  requiredRole?: ('owner' | 'admin' | 'subscriber' | 'learner')[];
 }
 
 export function SessionAuthProvider({

--- a/src/components/courses/CourseRegistrationForm.tsx
+++ b/src/components/courses/CourseRegistrationForm.tsx
@@ -1,0 +1,97 @@
+import { useState, type FormEvent } from 'react';
+import { registerForCourse } from '../../utils/auth-api';
+
+export default function CourseRegistrationForm() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!email.trim()) {
+      setError('メールアドレスを入力してください');
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError('有効なメールアドレスを入力してください');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    const result = await registerForCourse(email.trim());
+
+    if (result.success) {
+      setSent(true);
+    } else {
+      setError(result.error || 'エラーが発生しました。再試行してください。');
+    }
+
+    setLoading(false);
+  };
+
+  if (sent) {
+    return (
+      <div className="text-center py-8">
+        <div className="mb-4">
+          <svg
+            className="w-16 h-16 mx-auto text-green-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"
+            />
+          </svg>
+        </div>
+        <h3 className="text-xl font-bold text-gray-900 mb-2">
+          メールを確認してください
+        </h3>
+        <p className="text-gray-600 mb-4">
+          <span className="font-medium">{email}</span> に<br />
+          ログインリンクを送信しました。
+        </p>
+        <p className="text-sm text-gray-500">
+          メールのリンクをクリックすると、コースにアクセスできます。<br />
+          届かない場合は迷惑メールフォルダをご確認ください。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3 max-w-lg mx-auto">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="your@email.com"
+        autoComplete="email"
+        className="flex-1 px-4 py-3 border border-gray-300 rounded-lg
+                 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                 text-gray-900 placeholder-gray-400"
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg
+                 hover:bg-blue-700 transition-colors
+                 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+      >
+        {loading ? '登録中...' : '無料で登録する'}
+      </button>
+      {error && (
+        <p className="text-red-500 text-sm mt-1 sm:col-span-2 basis-full">{error}</p>
+      )}
+    </form>
+  );
+}

--- a/src/components/learn/LectureContent.tsx
+++ b/src/components/learn/LectureContent.tsx
@@ -52,13 +52,37 @@ export function LectureContent({ content }: Props) {
     return DOMPurify.sanitize(html);
   }, [content]);
 
-  // Apply syntax highlighting to code blocks after render
+  // Apply syntax highlighting and copy buttons to code blocks after render
   useEffect(() => {
-    if (containerRef.current) {
-      containerRef.current.querySelectorAll('pre code').forEach((block) => {
-        hljs.highlightElement(block as HTMLElement);
+    if (!containerRef.current) return;
+
+    containerRef.current.querySelectorAll('pre code').forEach((block) => {
+      hljs.highlightElement(block as HTMLElement);
+    });
+
+    containerRef.current.querySelectorAll('pre').forEach((pre) => {
+      if (pre.querySelector('.copy-btn')) return;
+      pre.style.position = 'relative';
+
+      const btn = document.createElement('button');
+      btn.className = 'copy-btn';
+      btn.textContent = 'Copy';
+      btn.style.cssText =
+        'position:absolute;top:8px;right:8px;padding:4px 10px;font-size:12px;' +
+        'background:rgba(255,255,255,0.15);color:#e5e7eb;border:1px solid rgba(255,255,255,0.2);' +
+        'border-radius:4px;cursor:pointer;transition:background 0.2s';
+      btn.addEventListener('mouseenter', () => { btn.style.background = 'rgba(255,255,255,0.25)'; });
+      btn.addEventListener('mouseleave', () => { btn.style.background = 'rgba(255,255,255,0.15)'; });
+      btn.addEventListener('click', () => {
+        const code = pre.querySelector('code');
+        if (code) {
+          navigator.clipboard.writeText(code.textContent || '');
+          btn.textContent = 'Copied!';
+          setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+        }
       });
-    }
+      pre.appendChild(btn);
+    });
   }, [sanitizedHtml]);
 
   return (

--- a/src/pages/courses/elementor-manual.astro
+++ b/src/pages/courses/elementor-manual.astro
@@ -1,0 +1,126 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import CourseRegistrationForm from '../../components/courses/CourseRegistrationForm';
+
+export const prerender = true;
+
+const sections = [
+  { title: 'Elementorの基本設定', lectures: 2 },
+  { title: 'レイアウト構造の理解', lectures: 2 },
+  { title: 'テキスト・画像の配置', lectures: 2 },
+  { title: 'デザイン調整とスタイリング', lectures: 2 },
+  { title: 'レスポンシブ対応', lectures: 2 },
+  { title: 'ヘッダー・フッター構築', lectures: 2 },
+  { title: 'お問い合わせフォーム', lectures: 2 },
+  { title: 'ページ構成とナビゲーション', lectures: 2 },
+  { title: '公開と運用のポイント', lectures: 2 },
+];
+const totalLectures = sections.reduce((sum, s) => sum + s.lectures, 0);
+---
+
+<BaseLayout
+  title="Elementor完全マニュアル - 無料コース"
+  description="全18レクチャーでElementorの使い方を体系的に学べる無料コース。コードブロック＋Copyボタン付きの実践的カリキュラム。"
+>
+  <!-- Hero -->
+  <section class="bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white">
+    <div class="max-w-4xl mx-auto px-6 py-20 md:py-28 text-center">
+      <p class="text-blue-400 font-medium text-sm tracking-wide uppercase mb-4">Free Course</p>
+      <h1 class="text-3xl md:text-5xl font-bold leading-tight mb-6">
+        Elementor完全マニュアル
+      </h1>
+      <p class="text-lg md:text-xl text-gray-300 mb-8 max-w-2xl mx-auto">
+        全{totalLectures}レクチャーの体系的カリキュラムで、<br class="hidden md:block" />
+        Elementorでのサイト構築を<strong class="text-white">ゼロからマスター</strong>
+      </p>
+      <a
+        href="#register"
+        class="inline-block px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors text-lg"
+      >
+        無料で始める
+      </a>
+    </div>
+  </section>
+
+  <!-- Features -->
+  <section class="py-16 md:py-24 bg-white">
+    <div class="max-w-5xl mx-auto px-6">
+      <h2 class="text-2xl md:text-3xl font-bold text-center text-gray-900 mb-12">
+        このコースの特徴
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center">
+          <div class="w-14 h-14 mx-auto mb-4 bg-blue-50 rounded-xl flex items-center justify-center">
+            <svg class="w-7 h-7 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+            </svg>
+          </div>
+          <h3 class="font-semibold text-gray-900 mb-2">体系的カリキュラム</h3>
+          <p class="text-gray-600 text-sm">
+            {sections.length}セクション・全{totalLectures}レクチャーで基礎から応用まで段階的に学習
+          </p>
+        </div>
+        <div class="text-center">
+          <div class="w-14 h-14 mx-auto mb-4 bg-blue-50 rounded-xl flex items-center justify-center">
+            <svg class="w-7 h-7 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+            </svg>
+          </div>
+          <h3 class="font-semibold text-gray-900 mb-2">コードブロック＋Copyボタン</h3>
+          <p class="text-gray-600 text-sm">
+            実際のコードスニペットをワンクリックでコピー。すぐに実践できる構成
+          </p>
+        </div>
+        <div class="text-center">
+          <div class="w-14 h-14 mx-auto mb-4 bg-blue-50 rounded-xl flex items-center justify-center">
+            <svg class="w-7 h-7 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+            </svg>
+          </div>
+          <h3 class="font-semibold text-gray-900 mb-2">ステップバイステップ</h3>
+          <p class="text-gray-600 text-sm">
+            スクリーンショット付きの手順解説で、初心者でも迷わず進められる
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Curriculum -->
+  <section class="py-16 md:py-24 bg-gray-50">
+    <div class="max-w-3xl mx-auto px-6">
+      <h2 class="text-2xl md:text-3xl font-bold text-center text-gray-900 mb-4">
+        カリキュラム
+      </h2>
+      <p class="text-center text-gray-500 mb-10">
+        {sections.length}セクション・全{totalLectures}レクチャー
+      </p>
+      <div class="space-y-3">
+        {sections.map((section, i) => (
+          <div class="bg-white rounded-lg border border-gray-200 px-5 py-4 flex items-center justify-between">
+            <div class="flex items-center gap-4">
+              <span class="text-sm font-bold text-blue-600 bg-blue-50 w-8 h-8 rounded-full flex items-center justify-center shrink-0">
+                {i + 1}
+              </span>
+              <span class="font-medium text-gray-900">{section.title}</span>
+            </div>
+            <span class="text-sm text-gray-500 shrink-0">{section.lectures}レクチャー</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Registration Form -->
+  <section id="register" class="py-16 md:py-24 bg-white">
+    <div class="max-w-2xl mx-auto px-6 text-center">
+      <h2 class="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
+        今すぐ無料で始める
+      </h2>
+      <p class="text-gray-600 mb-8">
+        メールアドレスを登録するだけで、全{totalLectures}レクチャーにアクセスできます。
+      </p>
+      <CourseRegistrationForm client:load />
+    </div>
+  </section>
+</BaseLayout>

--- a/src/utils/auth-api.ts
+++ b/src/utils/auth-api.ts
@@ -9,7 +9,7 @@ const PREMIUM_BASE = `${API_BASE}/premium`;
 export interface User {
   id: string;
   email: string;
-  role: 'owner' | 'admin' | 'subscriber';
+  role: 'owner' | 'admin' | 'subscriber' | 'learner';
 }
 
 export interface MagicLinkVerifyResponse {
@@ -81,6 +81,18 @@ async function authRequest<T>(
     const message = error instanceof Error ? error.message : 'Unknown error';
     return { success: false, error: `Network error: ${message}` };
   }
+}
+
+/**
+ * Register for a free course (creates subscriber + learner user + sends magic link)
+ */
+export async function registerForCourse(
+  email: string
+): Promise<AuthResponse<{ message: string }>> {
+  return authRequest('/auth/register', {
+    method: 'POST',
+    body: { email },
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Elementorマニュアルコース無料登録LP (`/courses/elementor-manual`) を追加
- CourseRegistrationForm React island でメール登録 → Magic Link フロー
- auth-api.ts に `registerForCourse()` 追加、User type に `learner` role 追加
- レクチャーページにコードブロック Copy ボタン追加

## Backend (edgeshift-premium, deployed separately)
- `POST /api/premium/auth/register` エンドポイント追加済み
- D1 CHECK constraint に `learner` role 追加済み（マイグレーション適用済み）
- Premium Worker デプロイ済み

## Test plan
- [ ] `/courses/elementor-manual` LP ページ表示確認
- [ ] メールアドレスで登録 → 成功メッセージ表示
- [ ] Magic Link メール受信 → TOTP 設定 → `/my/` リダイレクト
- [ ] D1 に subscribers + admin_users (learner) + subscriber_sequences レコード確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)