### PR TITLE
fix: reliable 401 detection with HTTP status code

### DIFF
--- a/src/components/learn/LearnCoursePage.tsx
+++ b/src/components/learn/LearnCoursePage.tsx
@@ -38,7 +38,7 @@ export function LearnCoursePage() {
       const result = await getLearnCourse(slug);
 
       if (!result.success) {
-        if (result.error?.includes('401') || result.error?.includes('Unauthorized')) {
+        if (result.status === 401) {
           setAuthRequired(true);
           setLoading(false);
           return;

--- a/src/components/learn/LearnCoursesPage.tsx
+++ b/src/components/learn/LearnCoursesPage.tsx
@@ -16,7 +16,7 @@ export function LearnCoursesPage() {
       const result = await getLearnCourses();
 
       if (!result.success) {
-        if (result.error?.includes('401') || result.error?.includes('Unauthorized')) {
+        if (result.status === 401) {
           setAuthRequired(true);
           setLoading(false);
           return;

--- a/src/components/learn/LearnLecturePage.tsx
+++ b/src/components/learn/LearnLecturePage.tsx
@@ -40,7 +40,7 @@ export function LearnLecturePage() {
 
       // Check for auth errors
       if (!lectureResult.success) {
-        if (lectureResult.error?.includes('401') || lectureResult.error?.includes('Unauthorized')) {
+        if (lectureResult.status === 401) {
           setAuthRequired(true);
           setLoading(false);
           return;
@@ -51,7 +51,7 @@ export function LearnLecturePage() {
       }
 
       if (!courseResult.success) {
-        if (courseResult.error?.includes('401') || courseResult.error?.includes('Unauthorized')) {
+        if (courseResult.status === 401) {
           setAuthRequired(true);
           setLoading(false);
           return;

--- a/src/utils/shop-api.ts
+++ b/src/utils/shop-api.ts
@@ -10,6 +10,7 @@ interface ApiResponse<T> {
   success: boolean;
   data?: T;
   error?: string;
+  status?: number;
 }
 
 // === Types ===
@@ -97,7 +98,7 @@ async function apiRequest<T>(
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: data.error || `Request failed: ${response.status}` };
+      return { success: false, error: data.error || `Request failed: ${response.status}`, status: response.status };
     }
 
     // Normalize response format


### PR DESCRIPTION
## Summary
- API が `"Authentication required"` というエラーメッセージを返すため、従来の `includes('401')` による文字列マッチングが動作しなかった
- `ApiResponse` に `status` フィールドを追加し、`status === 401` で確実に判定
- `CourseAuthGuard` の `registrationUrl` を動的化（前回コミット含む）

## Root Cause
`shop-api.ts` の `apiRequest` は `data.error || 'Request failed: 401'` を返すが、API が独自エラーメッセージ `"Authentication required"` を持つため `data.error` が優先され、`'401'` が含まれなかった

## Test plan
- [ ] 未認証で `/learn/elementor-multipage-manual` → 認証ガード UI 表示（リダイレクトなし）
- [ ] メール入力 → 送信 → 確認メッセージ表示
- [ ] `npm run check` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)