### PR TITLE
fix: auth guard registration link points to /shop

### DIFF
--- a/src/components/learn/LearnCoursePage.tsx
+++ b/src/components/learn/LearnCoursePage.tsx
@@ -75,8 +75,7 @@ export function LearnCoursePage() {
   };
 
   if (authRequired) {
-    const slug = window.location.pathname.split('/')[2];
-    return <CourseAuthGuard registrationUrl={slug ? `/shop/${slug}` : undefined} />;
+    return <CourseAuthGuard />;
   }
 
   if (loading) {

--- a/src/components/learn/LearnLecturePage.tsx
+++ b/src/components/learn/LearnLecturePage.tsx
@@ -70,8 +70,7 @@ export function LearnLecturePage() {
   }, []);
 
   if (authRequired) {
-    const slug = window.location.pathname.split('/')[2];
-    return <CourseAuthGuard registrationUrl={slug ? `/shop/${slug}` : undefined} />;
+    return <CourseAuthGuard />;
   }
 
   if (loading) {


### PR DESCRIPTION
## Summary
- Learn course slugs と shop product slugs が別体系のため、`/shop/{learnSlug}` が 404 になっていた
- `registrationUrl` のデフォルト `/shop`（コース一覧）を使うようにシンプル化

## Test plan
- [ ] 認証ガードの「こちら」リンクが `/shop` に遷移
- [ ] `/shop` でコース一覧が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)