### PR TITLE
feat: redesign Elementor course LP for Udemy learners

### DIFF
--- a/src/pages/courses/elementor-manual.astro
+++ b/src/pages/courses/elementor-manual.astro
@@ -4,120 +4,209 @@ import CourseRegistrationForm from '../../components/courses/CourseRegistrationF
 
 export const prerender = true;
 
+// Udemy Module 2-10 対応のセクション
 const sections = [
-  { title: 'Elementorの基本設定', lectures: 2 },
-  { title: 'レイアウト構造の理解', lectures: 2 },
-  { title: 'テキスト・画像の配置', lectures: 2 },
-  { title: 'デザイン調整とスタイリング', lectures: 2 },
-  { title: 'レスポンシブ対応', lectures: 2 },
-  { title: 'ヘッダー・フッター構築', lectures: 2 },
-  { title: 'お問い合わせフォーム', lectures: 2 },
-  { title: 'ページ構成とナビゲーション', lectures: 2 },
-  { title: '公開と運用のポイント', lectures: 2 },
+  { module: 2, title: 'WordPress初期設定', lectures: 2 },
+  { module: 3, title: 'Elementor基本設定', lectures: 2 },
+  { module: 4, title: 'Heroセクション', lectures: 2 },
+  { module: 5, title: 'コンテンツセクション', lectures: 3 },
+  { module: 6, title: 'Aboutページ', lectures: 2 },
+  { module: 7, title: 'サービスページ', lectures: 2 },
+  { module: 8, title: 'コンタクトページ', lectures: 2 },
+  { module: 9, title: 'ブログページ', lectures: 1 },
+  { module: 10, title: 'メニュー・ツール', lectures: 2 },
 ];
+
 const totalLectures = sections.reduce((sum, s) => sum + s.lectures, 0);
+
+const painPoints = [
+  {
+    icon: 'rewind',
+    text: '動画を何度も巻き戻して、コードや手順を確認している',
+  },
+  {
+    icon: 'clipboard',
+    text: '動画からコードをコピーできず、手入力でタイプミスが起きる',
+  },
+  {
+    icon: 'search',
+    text: '「あの手順どこだっけ？」と動画を探し回る時間がもったいない',
+  },
+];
+
+const features = [
+  {
+    title: 'コードブロック＋Copyボタン',
+    description: '動画内のコードスニペットをワンクリックでコピー。手入力のタイプミスゼロ。',
+    image: '/images/lp/code-block.png',
+  },
+  {
+    title: 'いつでもピンポイント参照',
+    description: 'テキスト検索で必要な手順にすぐアクセス。動画を探し回る必要なし。',
+    image: '/images/lp/step-by-step.png',
+  },
+  {
+    title: '自分のペースで進められる',
+    description: '動画の速度に縛られず、理解できた部分は飛ばし、難しい部分はじっくり読める。',
+    image: '/images/lp/curriculum.png',
+  },
+];
+
+const registrationSteps = [
+  { number: 1, title: 'メールアドレスを入力', description: '下のフォームにメールアドレスを入力' },
+  { number: 2, title: '届いたメールのリンクをクリック', description: '確認メールのリンクをクリックするだけ' },
+  { number: 3, title: 'すべてのレクチャーにアクセス', description: '全18レクチャーのテキストマニュアルがすぐに閲覧可能' },
+];
+
+const stats = [
+  { value: '9', label: 'セクション' },
+  { value: '18', label: 'レクチャー' },
+  { value: '無料', label: '受講料' },
+];
 ---
 
 <BaseLayout
-  title="Elementor完全マニュアル - 無料コース"
-  description="全18レクチャーでElementorの使い方を体系的に学べる無料コース。コードブロック＋Copyボタン付きの実践的カリキュラム。"
+  title="Elementorテキストマニュアル - Udemy受講者向け無料コース"
+  description="Udemyコースの学習効率を最大化するテキストマニュアル。コピペ可能なコードブロック付きで、動画を巻き戻す手間を解消。全18レクチャー無料。"
 >
-  <!-- Hero -->
-  <section class="bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white">
+  <!-- Section 1: Hero (white) -->
+  <section class="bg-white">
     <div class="max-w-4xl mx-auto px-6 py-20 md:py-28 text-center">
-      <p class="text-blue-400 font-medium text-sm tracking-wide uppercase mb-4">Free Course</p>
-      <h1 class="text-3xl md:text-5xl font-bold leading-tight mb-6">
-        Elementor完全マニュアル
+      <span class="inline-block px-4 py-1.5 rounded-full text-sm font-medium bg-[var(--color-accent-light)] text-[var(--color-accent)] mb-6">
+        Udemy受講者向け / 無料テキストマニュアル
+      </span>
+      <h1 class="text-3xl md:text-5xl font-bold leading-tight text-[var(--color-text)] mb-6">
+        Udemyコースの学習効率を最大化する<br class="hidden md:block" />テキストマニュアル
       </h1>
-      <p class="text-lg md:text-xl text-gray-300 mb-8 max-w-2xl mx-auto">
-        全{totalLectures}レクチャーの体系的カリキュラムで、<br class="hidden md:block" />
-        Elementorでのサイト構築を<strong class="text-white">ゼロからマスター</strong>
+      <p class="text-lg md:text-xl text-[var(--color-text-secondary)] mb-8 max-w-2xl mx-auto">
+        動画を巻き戻してコードを確認する手間を、コピペ可能なテキストで解消。Udemyコースと併用することで、学習速度が格段にアップします。
       </p>
       <a
         href="#register"
-        class="inline-block px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors text-lg"
+        class="inline-block px-8 py-4 bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] text-white font-semibold rounded-lg transition-colors text-lg"
       >
-        無料で始める
+        今すぐウェブマニュアルを手に入れる
       </a>
-    </div>
-  </section>
-
-  <!-- Features -->
-  <section class="py-16 md:py-24 bg-white">
-    <div class="max-w-5xl mx-auto px-6">
-      <h2 class="text-2xl md:text-3xl font-bold text-center text-gray-900 mb-12">
-        このコースの特徴
-      </h2>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-        <div class="text-center">
-          <div class="w-14 h-14 mx-auto mb-4 bg-blue-50 rounded-xl flex items-center justify-center">
-            <svg class="w-7 h-7 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-            </svg>
-          </div>
-          <h3 class="font-semibold text-gray-900 mb-2">体系的カリキュラム</h3>
-          <p class="text-gray-600 text-sm">
-            {sections.length}セクション・全{totalLectures}レクチャーで基礎から応用まで段階的に学習
-          </p>
-        </div>
-        <div class="text-center">
-          <div class="w-14 h-14 mx-auto mb-4 bg-blue-50 rounded-xl flex items-center justify-center">
-            <svg class="w-7 h-7 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-            </svg>
-          </div>
-          <h3 class="font-semibold text-gray-900 mb-2">コードブロック＋Copyボタン</h3>
-          <p class="text-gray-600 text-sm">
-            実際のコードスニペットをワンクリックでコピー。すぐに実践できる構成
-          </p>
-        </div>
-        <div class="text-center">
-          <div class="w-14 h-14 mx-auto mb-4 bg-blue-50 rounded-xl flex items-center justify-center">
-            <svg class="w-7 h-7 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-            </svg>
-          </div>
-          <h3 class="font-semibold text-gray-900 mb-2">ステップバイステップ</h3>
-          <p class="text-gray-600 text-sm">
-            スクリーンショット付きの手順解説で、初心者でも迷わず進められる
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Curriculum -->
-  <section class="py-16 md:py-24 bg-gray-50">
-    <div class="max-w-3xl mx-auto px-6">
-      <h2 class="text-2xl md:text-3xl font-bold text-center text-gray-900 mb-4">
-        カリキュラム
-      </h2>
-      <p class="text-center text-gray-500 mb-10">
-        {sections.length}セクション・全{totalLectures}レクチャー
-      </p>
-      <div class="space-y-3">
-        {sections.map((section, i) => (
-          <div class="bg-white rounded-lg border border-gray-200 px-5 py-4 flex items-center justify-between">
-            <div class="flex items-center gap-4">
-              <span class="text-sm font-bold text-blue-600 bg-blue-50 w-8 h-8 rounded-full flex items-center justify-center shrink-0">
-                {i + 1}
-              </span>
-              <span class="font-medium text-gray-900">{section.title}</span>
-            </div>
-            <span class="text-sm text-gray-500 shrink-0">{section.lectures}レクチャー</span>
+      <div class="mt-12 pt-8 border-t border-[var(--color-border)] grid grid-cols-3 gap-8 max-w-md mx-auto">
+        {stats.map((stat) => (
+          <div>
+            <p class="text-2xl md:text-3xl font-bold text-[var(--color-text)]">{stat.value}</p>
+            <p class="text-sm text-[var(--color-text-muted)]">{stat.label}</p>
           </div>
         ))}
       </div>
     </div>
   </section>
 
-  <!-- Registration Form -->
-  <section id="register" class="py-16 md:py-24 bg-white">
-    <div class="max-w-2xl mx-auto px-6 text-center">
-      <h2 class="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
-        今すぐ無料で始める
+  <!-- Section 2: Problem (gray-50) -->
+  <section class="py-16 md:py-24 bg-gray-50">
+    <div class="max-w-5xl mx-auto px-6">
+      <h2 class="text-2xl md:text-3xl font-bold text-center text-[var(--color-text)] mb-12">
+        動画学習、こんな経験ありませんか？
       </h2>
-      <p class="text-gray-600 mb-8">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {painPoints.map((point) => (
+          <div class="bg-white rounded-lg border border-[var(--color-border)] p-6">
+            <div class="w-12 h-12 rounded-lg bg-red-50 flex items-center justify-center mb-4">
+              {point.icon === 'rewind' && (
+                <svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z" />
+                </svg>
+              )}
+              {point.icon === 'clipboard' && (
+                <svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+              )}
+              {point.icon === 'search' && (
+                <svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              )}
+            </div>
+            <p class="text-[var(--color-text-secondary)]">{point.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Solution (white) -->
+  <section class="py-16 md:py-24 bg-white">
+    <div class="max-w-5xl mx-auto px-6">
+      <h2 class="text-2xl md:text-3xl font-bold text-center text-[var(--color-text)] mb-12">
+        テキストマニュアルで解決
+      </h2>
+      <div class="space-y-16">
+        {features.map((feature, i) => (
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
+            <div class={i % 2 === 1 ? 'md:order-2' : ''}>
+              <h3 class="text-xl font-bold text-[var(--color-text)] mb-3">{feature.title}</h3>
+              <p class="text-[var(--color-text-secondary)]">{feature.description}</p>
+            </div>
+            <div class={i % 2 === 1 ? 'md:order-1' : ''}>
+              <div class="aspect-video bg-gray-200 rounded-lg border border-[var(--color-border)] flex items-center justify-center">
+                <span class="text-[var(--color-text-muted)] text-sm">Screenshot coming soon</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 4: Curriculum (gray-50) -->
+  <section class="py-16 md:py-24 bg-gray-50">
+    <div class="max-w-3xl mx-auto px-6">
+      <h2 class="text-2xl md:text-3xl font-bold text-center text-[var(--color-text)] mb-4">
+        Udemyコースに対応した全{sections.length}セクション
+      </h2>
+      <p class="text-center text-[var(--color-text-muted)] mb-10">
+        {sections.length}セクション・全{totalLectures}レクチャー
+      </p>
+      <div class="space-y-3">
+        {sections.map((section) => (
+          <div class="bg-white rounded-lg border border-gray-200 px-5 py-4 flex items-center justify-between">
+            <div class="flex items-center gap-4">
+              <span class="text-sm font-bold text-[var(--color-accent)] bg-[var(--color-accent-light)] w-8 h-8 rounded-full flex items-center justify-center shrink-0">
+                {section.module}
+              </span>
+              <span class="font-medium text-[var(--color-text)]">{section.title}</span>
+            </div>
+            <span class="text-sm text-[var(--color-text-muted)] shrink-0">{section.lectures}レクチャー</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 5: Registration Flow (white) -->
+  <section class="py-16 md:py-24 bg-white">
+    <div class="max-w-4xl mx-auto px-6">
+      <h2 class="text-2xl md:text-3xl font-bold text-center text-[var(--color-text)] mb-12">
+        かんたん3ステップで受講開始
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {registrationSteps.map((step) => (
+          <div class="text-center">
+            <div class="w-14 h-14 rounded-full bg-[var(--color-accent)] text-white text-xl font-bold flex items-center justify-center mx-auto mb-4">
+              {step.number}
+            </div>
+            <h3 class="font-semibold text-[var(--color-text)] mb-2">{step.title}</h3>
+            <p class="text-sm text-[var(--color-text-secondary)]">{step.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 6: CTA + Form (gray-50) -->
+  <section id="register" class="py-16 md:py-24 bg-gray-50">
+    <div class="max-w-2xl mx-auto px-6 text-center">
+      <h2 class="text-2xl md:text-3xl font-bold text-[var(--color-text)] mb-4">
+        今すぐウェブマニュアルを手に入れる
+      </h2>
+      <p class="text-[var(--color-text-secondary)] mb-8">
         メールアドレスを登録するだけで、全{totalLectures}レクチャーにアクセスできます。
       </p>
       <CourseRegistrationForm client:load signupPageSlug="elementor-manual" />


### PR DESCRIPTION
## Summary
- Redesign `/courses/elementor-manual` LP from 4 generic sections to 6 targeted sections (Hero → Problem → Solution → Curriculum → Registration Flow → CTA+Form)
- Shift messaging from generic "master Elementor" to Udemy learner-specific "maximize your video learning with text manual"
- Update curriculum to match actual Udemy Modules 2-10 (9 sections, 18 lectures) and align design with purple accent design tokens

## Test plan
- [ ] `npm run check` passes with 0 errors
- [ ] `npm run build` succeeds with SSG prerender
- [ ] All 6 sections render correctly on desktop and mobile
- [ ] Hero CTA scrolls to `#register` form section
- [ ] Stats bar shows correct values (9 sections / 18 lectures / 無料)
- [ ] Curriculum displays Udemy Module 2-10 with correct lecture counts
- [ ] Registration form accepts email input and submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)