### PR TITLE
feat: add standalone /contact page

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,61 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import ContactForm from '../components/ContactForm.astro';
+
+export const prerender = true;
+---
+
+<BaseLayout
+  title="お問い合わせ - EdgeShift"
+  description="EdgeShiftへのお問い合わせはこちら。プロジェクトのご相談、技術的なご質問など、お気軽にお問い合わせください。"
+>
+  <section class="py-24 bg-white">
+    <div class="max-w-4xl mx-auto px-6">
+      <div class="text-center mb-10">
+        <h1 class="text-3xl font-bold text-[var(--color-text)] mb-6">Contact</h1>
+        <p class="text-[var(--color-text-secondary)] max-w-lg mx-auto">
+          プロジェクトのご相談、技術的なご質問など、お気軽にお問い合わせください。
+        </p>
+      </div>
+
+      <ContactForm endpoint="https://edgeshift.tech/api/contact" />
+
+      <div class="mt-12 pt-8 border-t border-[var(--color-border)]">
+        <p class="text-center text-[var(--color-text-muted)] text-sm mb-4">または SNS でもお気軽にどうぞ</p>
+        <div class="flex justify-center gap-4">
+          <a
+            href="https://github.com/kuma8088"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+            aria-label="GitHub"
+          >
+            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+            </svg>
+          </a>
+          <a
+            href="https://x.com/EdgeShift8088"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+            aria-label="X (Twitter)"
+          >
+            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+            </svg>
+          </a>
+          <a
+            href="https://zenn.dev/kuma8088"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+            aria-label="Zenn"
+          >
+            <img src="/images/zenn-logo.svg" alt="Zenn" class="w-6 h-6 opacity-60 hover:opacity-100 transition-opacity" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary

- Add `/contact` page reusing existing `ContactForm.astro` component
- Matches index.astro contact section layout (heading, form, SNS links)
- Prerendered as static page (`export const prerender = true`)

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run build` — `/contact/index.html` generated
- [x] Playwright visual verification — form fields, SNS links, footer all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)