### PR TITLE
fix: use fetch+blob download to ensure correct filename

### DIFF
--- a/src/components/my/MyPurchasesPage.tsx
+++ b/src/components/my/MyPurchasesPage.tsx
@@ -16,7 +16,21 @@ function DownloadButton({ productId }: { productId: string }) {
       if (response.status === 401) { setError('ログインが必要です'); return; }
       if (response.status === 403) { setError('アクセス権がありません'); return; }
       if (!response.ok) { setError('ダウンロードに失敗しました'); return; }
-      window.open(url, '_blank');
+      // Fetch file as blob and trigger download with correct filename
+      const dlResponse = await fetch(url, { credentials: 'include' });
+      if (!dlResponse.ok) { setError('ダウンロードに失敗しました'); return; }
+      const disposition = dlResponse.headers.get('Content-Disposition');
+      const filenameMatch = disposition?.match(/filename="?([^";\n]+)"?/);
+      const filename = filenameMatch?.[1] || 'download';
+      const blob = await dlResponse.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = blobUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(blobUrl);
     } catch {
       setError('ネットワークエラー');
     } finally {


### PR DESCRIPTION
## Summary

- Replace `window.open()` with `fetch` → `Blob` → `<a download>` pattern for file downloads
- Extracts filename from `Content-Disposition` header instead of relying on browser URL interpretation
- Fixes issue where downloads saved with UUID or "download" as filename instead of the actual file name (e.g., `test-download.zip`)

**Affected components:**
- `DownloadSection.tsx` (shop product page)
- `MyPurchasesPage.tsx` (subscriber my-page)

## Test plan

- [ ] Shop page: click download button → file saves with correct filename
- [ ] My page: click download button → file saves with correct filename
- [ ] Verify `Content-Disposition` header filename is used, not URL path

🤖 Generated with [Claude Code](https://claude.com/claude-code)