### PR TITLE
feat: redesign success page and add email brand settings UI

### DIFF
--- a/src/components/shop/ShopProductDetail.tsx
+++ b/src/components/shop/ShopProductDetail.tsx
@@ -157,7 +157,7 @@ export default function ShopProductDetail() {
     const result = await checkoutProduct({
       product_id: product.id,
       email: checkoutEmail,
-      success_url: `${origin}/shop/success`,
+      success_url: `${origin}/shop/success?email=${encodeURIComponent(checkoutEmail)}&product=${encodeURIComponent(product.name)}`,
       cancel_url: window.location.href,
     });
 

--- a/src/pages/shop/success.astro
+++ b/src/pages/shop/success.astro
@@ -3,28 +3,76 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
 const rawSlug = Astro.url.searchParams.get('course_slug');
 const courseSlug = rawSlug && /^[a-z0-9-]+$/.test(rawSlug) ? rawSlug : null;
+const email = Astro.url.searchParams.get('email') || '';
+const productName = Astro.url.searchParams.get('product') || '';
+
+// Mask email for display: na***@gmail.com
+const maskedEmail = email
+  ? email.replace(/^(.{2})(.*)(@.*)$/, (_, a, b, c) => a + '*'.repeat(Math.min(b.length, 5)) + c)
+  : '';
+
+const emailSubject = productName
+  ? `EdgeShift - 「${productName}」のダウンロード`
+  : 'EdgeShift - ダウンロード';
 ---
 
 <BaseLayout title="購入完了" description="ご購入ありがとうございます">
-  <div class="max-w-2xl mx-auto px-4 py-16 text-center">
-    <div class="mb-8">
+  <div class="max-w-2xl mx-auto px-4 py-16">
+    <div class="text-center mb-10">
       <div class="w-16 h-16 mx-auto bg-green-100 rounded-full flex items-center justify-center mb-4">
         <svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
         </svg>
       </div>
-      <h1 class="text-3xl font-bold text-gray-900 mb-4">購入ありがとうございます！</h1>
-      <p class="text-gray-600 mb-8">
-        ご購入の確認メールをお送りしました。<br />
-        ダウンロード可能な商品は、メール内のリンクからダウンロードできます。
-      </p>
+      <h1 class="text-3xl font-bold text-gray-900 mb-3">購入ありがとうございます！</h1>
+      <p class="text-gray-600">ダウンロードリンクを含むメールをお送りしました。</p>
     </div>
+
+    <div class="bg-white border border-gray-200 rounded-xl p-6 mb-8 space-y-4">
+      <h2 class="text-lg font-semibold text-gray-900">メールをご確認ください</h2>
+
+      {maskedEmail && (
+        <div class="flex items-start gap-3">
+          <span class="text-gray-400 mt-0.5">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </span>
+          <div>
+            <p class="text-sm text-gray-500">送信先</p>
+            <p class="text-gray-900 font-medium">{maskedEmail}</p>
+          </div>
+        </div>
+      )}
+
+      <div class="flex items-start gap-3">
+        <span class="text-gray-400 mt-0.5">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+          </svg>
+        </span>
+        <div>
+          <p class="text-sm text-gray-500">件名</p>
+          <p class="text-gray-900 font-medium">{emailSubject}</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-8 text-sm text-amber-800 space-y-2">
+      <p class="font-medium">メールが届かない場合</p>
+      <ol class="list-decimal list-inside space-y-1 text-amber-700">
+        <li>迷惑メールフォルダをご確認ください</li>
+        <li>数分待ってから再度ご確認ください</li>
+        <li>それでも届かない場合は<a href="/contact" class="underline font-medium">お問い合わせページ</a>からご連絡ください</li>
+      </ol>
+    </div>
+
     {courseSlug && (
-      <div class="mb-8 p-6 bg-blue-50 rounded-lg border border-blue-200">
+      <div class="bg-blue-50 border border-blue-200 rounded-xl p-5 mb-8">
         <p class="text-gray-700 mb-3">会員限定コンテンツもご利用いただけます</p>
         <a
           href={`/learn/${courseSlug}`}
-          class="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          class="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
         >
           コースを見る
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -33,18 +81,13 @@ const courseSlug = rawSlug && /^[a-z0-9-]+$/.test(rawSlug) ? rawSlug : null;
         </a>
       </div>
     )}
-    <div class="flex gap-4 justify-center">
+
+    <div class="text-center">
       <a
         href="/shop"
-        class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        class="text-sm text-gray-500 hover:text-gray-700 transition-colors"
       >
-        ショップに戻る
-      </a>
-      <a
-        href="/my"
-        class="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-      >
-        マイページ
+        &larr; ショップに戻る
       </a>
     </div>
   </div>

--- a/src/utils/admin-api.ts
+++ b/src/utils/admin-api.ts
@@ -537,6 +537,20 @@ export async function previewTemplate(data: PreviewTemplateData) {
   return apiRequest<{ html: string }>('/templates/preview', { method: 'POST', body: data });
 }
 
+// Email Brand Settings API (Premium Worker)
+export interface EmailBrandSettings {
+  email_primary_color?: string;
+  email_footer_html?: string;
+}
+
+export async function getEmailBrandSettings() {
+  return apiRequest<EmailBrandSettings>('/premium/email-settings');
+}
+
+export async function updateEmailBrandSettings(data: EmailBrandSettings) {
+  return apiRequest<{ success: boolean }>('/premium/email-settings', { method: 'PUT', body: data });
+}
+
 export interface TestSendTemplateData {
   template_id: string;
   content: string;


### PR DESCRIPTION
## Summary
- Redesigned purchase success page: shows masked email address, expected subject line, spam folder check instructions, and contact link (removed non-functional マイページ button that led to login wall)
- Success URL now includes email and product name from Stripe checkout
- Added email brand settings section to admin brand settings page (button color picker, footer HTML editor)
- Added public page preview links (success, shop, contact) to admin brand settings
- Added `uploadProductImage()` and email brand settings API functions to admin-api.ts

## Test plan
- [ ] Purchase success page shows masked email and subject line
- [ ] "メールが届かない場合" section displays correctly with contact link
- [ ] Admin brand settings page shows email settings (color picker, footer HTML)
- [ ] Saving email settings persists and reloads correctly
- [ ] Public page links in brand settings open correct pages

🤖 Generated with [Claude Code](https://claude.ai/code)